### PR TITLE
Add infrastructure for "Kafka, Flink and CrateDB" tutorial

### DIFF
--- a/spikes/kafka-flink/.gitignore
+++ b/spikes/kafka-flink/.gitignore
@@ -1,0 +1,3 @@
+*.json
+*.tar.gz
+*.jar

--- a/spikes/kafka-flink/Makefile
+++ b/spikes/kafka-flink/Makefile
@@ -1,0 +1,15 @@
+#
+# Sandbox operations for IIoT tutorials
+#
+
+# Start foundation infrastructure.
+start:
+	docker-compose up
+
+# Publish a message to the Kafka broker.
+test-publish:
+	echo hello | kafkacat -b localhost -P -t testdrive
+
+# Consume messages from the Kafka broker.
+test-consume:
+	kafkacat -b localhost -C -t testdrive -o end

--- a/spikes/kafka-flink/README.Unix.rst
+++ b/spikes/kafka-flink/README.Unix.rst
@@ -1,0 +1,114 @@
+##############################################
+Apache Kafka, Apache Flink and CrateDB on Unix
+##############################################
+
+*****
+About
+*****
+
+This document will outline how to run the tutorial on Linux, macOS and WSL2.
+
+
+*****
+Setup
+*****
+
+Prepare a sandbox directory::
+
+    mkdir -p sandbox/kafka-flink-cratedb
+    cd ./sandbox/kafka-flink-cratedb/
+
+
+Infrastructure
+==============
+
+In order to start Kafka, Flink and CrateDB, invoke::
+
+    git clone https://github.com/crate/cratedb-examples
+    cd cratedb-examples
+    git checkout amo/kafka-flink
+    cd spikes/kafka-flink
+    docker-compose up
+
+If you don't have Git installed on your machine, you can get hold of the
+``docker-compose.yml`` file in any way you like. So, this will also work::
+
+    wget https://raw.githubusercontent.com/crate/cratedb-examples/amo/kafka-flink/spikes/kafka-flink/docker-compose.yml
+    docker-compose up
+
+Pre-flight checks
+-----------------
+
+In order to check if the Kafka subsystem works, have a look at the "Kafka"
+section within the ``notes.rst`` document.
+
+
+Resources
+=========
+
+Create a Kafka topic for publishing messages and a CrateDB table to receive
+data from the taxi rides data feed::
+
+    # Create Kafka topic
+    docker run -it --network=scada-demo confluentinc/cp-kafka:6.1.1 \
+        kafka-topics --bootstrap-server kafka-broker:9092 --create --replication-factor 1 --partitions 1 --topic rides
+
+    # Create CrateDB table
+    docker run -it --network=scada-demo westonsteimel/httpie \
+        http "cratedb:4200/_sql?pretty" stmt='CREATE TABLE "taxi_rides" ("payload" OBJECT(DYNAMIC))'
+
+.. note::
+
+    In order to drop the database table, try ``http "localhost:4200/_sql?pretty" stmt='DROP TABLE "taxi_rides"'``.
+
+Pipeline job
+============
+
+Acquire and invoke the Flink job::
+
+    # Acquire Flink job
+    VERSION=0.2
+    JARFILE="cratedb-flink-jobs-${VERSION}.jar"
+    wget https://github.com/crate/cratedb-flink-jobs/releases/download/${VERSION}/${JARFILE}
+
+    # Invoke Flink job
+    docker run -it --network=scada-demo --volume=$(pwd)/${JARFILE}:/${JARFILE} flink:1.12 \
+        flink run --jobmanager=flink-jobmanager:8081 /${JARFILE} \
+            --kafka.servers kafka-broker:9092 \
+            --kafka.topic rides \
+            --crate.hosts cratedb:5432 \
+            --crate.table taxi_rides
+
+
+*****
+Usage
+*****
+
+This section outlines how to acquire the NYC Taxi 2017 dataset in JSON format
+and feed it to the Kafka topic ``rides``. After or while data is processed,
+the number of records in the target database table will be inquired.
+
+Obtain raw data::
+
+    # Acquire NYC Taxi 2017 dataset in JSON format
+    wget https://gist.github.com/kovrus/328ba1b041dfbd89e55967291ba6e074/raw/7818724cb64a5d283db7f815737c9e198a22bee4/nyc-yellow-taxi-2017.tar.gz
+
+    # Extract archive
+    tar -xvf nyc-yellow-taxi-2017.tar.gz
+
+    # Create a subset of the data (5000 records) for concluding the first steps
+    cat nyc-yellow-taxi-2017.json | head -n 5000 > nyc-yellow-taxi-2017-subset.json
+
+Subscribe to the topic to receive messages::
+
+    docker run -it --network=scada-demo edenhill/kafkacat:1.6.0 kafkacat -b kafka-broker -C -t rides -o end
+
+Publish data to the Kafka topic::
+
+    cat nyc-yellow-taxi-2017-subset.json | docker run -i --network=scada-demo confluentinc/cp-kafka:6.1.1 \
+        kafka-console-producer --bootstrap-server kafka-broker:9092 --topic rides
+
+Check the number of records in database::
+
+    docker run -it --network=scada-demo westonsteimel/httpie \
+        http "cratedb:4200/_sql?pretty" stmt='SELECT COUNT(*) FROM "taxi_rides"'

--- a/spikes/kafka-flink/README.Windows.rst
+++ b/spikes/kafka-flink/README.Windows.rst
@@ -1,0 +1,104 @@
+#################################################
+Apache Kafka, Apache Flink and CrateDB on Windows
+#################################################
+
+*****
+About
+*****
+
+This document will outline how to run the tutorial on Windows 10, using PowerShell.
+On Windows 10, please use those commands with PowerShell 3+ (pwsh) and `Docker Desktop on Windows`_.
+
+
+*****
+Setup
+*****
+
+Prepare a sandbox directory::
+
+    New-Item sandbox/kafka-flink-cratedb -ItemType Directory -ErrorAction SilentlyContinue
+    cd ./sandbox/kafka-flink-cratedb/
+
+
+Infrastructure
+==============
+
+In order to start Kafka, Flink and CrateDB, invoke::
+
+    Set-Variable -Name DOCKER_COMPOSE_URL -value "https://raw.githubusercontent.com/crate/cratedb-examples/amo/kafka-flink/spikes/kafka-flink/docker-compose.yml"
+    Invoke-WebRequest -Uri "${DOCKER_COMPOSE_URL}" -OutFile "docker-compose.yml"
+    docker-compose up
+
+Resources
+=========
+
+Create a Kafka topic for publishing messages and a CrateDB table to receive
+data from the taxi rides data feed::
+
+    # Create Kafka topic
+    docker run -it --network=scada-demo confluentinc/cp-kafka:6.1.1 `
+        kafka-topics --bootstrap-server kafka-broker:9092 --create --replication-factor 1 --partitions 1 --topic rides
+
+    # Create CrateDB table
+    docker run -it --network=scada-demo westonsteimel/httpie `
+        http "cratedb:4200/_sql?pretty" stmt='CREATE TABLE "taxi_rides" ("payload" OBJECT(DYNAMIC))'
+
+
+
+Pipeline job
+============
+
+Acquire and invoke the Flink job::
+
+    # Acquire Flink job
+    Set-Variable -Name VERSION -value 0.2
+    Set-Variable -Name JARFILE -value "cratedb-flink-jobs-${VERSION}.jar"
+    Set-Variable -Name JARURL -value "https://github.com/crate/cratedb-flink-jobs/releases/download/${VERSION}/${JARFILE}"
+    Set-Variable -Name HERE (Get-Location)
+    Invoke-WebRequest -Uri "${JARURL}" -OutFile "${JARFILE}"
+
+    # Invoke Flink job
+    docker run -it --network=scada-demo --volume=${HERE}/${JARFILE}:/${JARFILE} flink:1.12 `
+        flink run --jobmanager=flink-jobmanager:8081 /${JARFILE} `
+            --kafka.servers kafka-broker:9092 `
+            --kafka.topic rides `
+            --crate.hosts cratedb:5432 `
+            --crate.table taxi_rides
+
+
+*****
+Usage
+*****
+
+This section outlines how to acquire the NYC Taxi 2017 dataset in JSON format
+and feed it to the Kafka topic ``rides``. After or while data is processed,
+the number of records in the target database table will be inquired.
+
+Obtain raw data::
+
+    # Acquire NYC Taxi 2017 dataset in JSON format
+    Invoke-WebRequest -Uri "https://gist.github.com/kovrus/328ba1b041dfbd89e55967291ba6e074/raw/7818724cb64a5d283db7f815737c9e198a22bee4/nyc-yellow-taxi-2017.tar.gz" -OutFile "nyc-yellow-taxi-2017.tar.gz"
+
+    # Extract archive
+    tar -xvf nyc-yellow-taxi-2017.tar.gz
+
+    # Create a subset of the data (5000 records) for concluding the first steps
+    gc ./nyc-yellow-taxi-2017.json | select -first 5000 > nyc-yellow-taxi-2017-subset.json
+
+Subscribe to the topic to receive messages::
+
+    docker run -it --network=scada-demo edenhill/kafkacat:1.6.0 kafkacat -b kafka-broker -C -t rides -o end
+
+Publish data to the Kafka topic::
+
+    gc nyc-yellow-taxi-2017-subset.json | docker run -i --network=scada-demo confluentinc/cp-kafka:6.1.1 `
+        kafka-console-producer --bootstrap-server kafka-broker:9092 --topic rides
+
+Check the number of records in database::
+
+    docker run -it --network=scada-demo westonsteimel/httpie `
+        http "cratedb:4200/_sql?pretty" stmt='SELECT COUNT(*) FROM "taxi_rides"'
+
+
+
+.. _Docker Desktop on Windows: https://docs.docker.com/docker-for-windows/install/

--- a/spikes/kafka-flink/README.rst
+++ b/spikes/kafka-flink/README.rst
@@ -1,0 +1,178 @@
+#####################################################
+Building IoT applications with open-source components
+#####################################################
+
+
+**********************************************
+Part 1: Apache Kafka, Apache Flink and CrateDB
+**********************************************
+
+
+Introduction
+============
+
+Kafka, Flink, and CrateDB are all distributed systems that provide elastic
+scaling, fault tolerance, and high-throughput, low-latency performance via
+parallel processing. Particularly, the use of CrateDB makes the stack an
+extremely good fit for handling industrial time-series workloads.
+
+The front line of the stack is Apache Kafka, used to queue messages received
+from the IoT sensors and devices, making that data highly available to systems
+that need it.
+
+Apache Flink is a stream processing framework that executes data pipelines,
+i.e. stateful computations over the data streams.
+Flink jobs consist of multiple components including source, sink, and the set
+of transformation operators that are applied to a data stream.
+
+CrateDB is a new kind of distributed SQL database built for IIoT applications.
+It will store and query data that has been processed and enriched by Apache
+Flink.
+
+
+About
+=====
+
+This tutorial shows how to build a simple data ingestion pipeline with open
+source software components.
+It will outline how to acquire and publish data to Kafka, process it using
+Flink and store the data stream into CrateDB.
+It describes this system as a part of the CrateDB reference architecture and
+can be used as a blueprint for building own applications.
+
+The following versions of software components are used:
+
+- Confluent Kafka 6.1.1
+- Apache Flink 1.12
+- CrateDB 4.5.0
+- Apache Kafka Connector for Flink 1.12.2
+- JDBC Connector for Flink 1.12.2
+- CrateDB JDBC driver 2.6.0
+
+
+Overview
+========
+
+The Flink pipeline job will subscribe to the Kafka topic ``rides`` in order to
+consume the data feed and store its records into the CrateDB table
+``taxi_rides``.
+
+Following the `Kafka + Flink: A Practical, How-To Guide`_, there is an example job
+for importing the NYC taxi dataset at https://github.com/crate/cratedb-flink-jobs.
+It uses those connectors and drivers to conclude its job:
+
+- `Apache Kafka Connector for Flink`_
+- `JDBC Connector for Flink`_
+- `CrateDB JDBC driver`_
+
+
+Details
+=======
+
+Foundation infrastructure
+-------------------------
+
+The simplest possible way to setup and start all software components on a
+developer workstation is to use Docker Compose and Docker. Thus, this tutorial
+does not address topics like high-availability, fault-tolerance, scalability
+and performance considerations.
+
+Both Apache Flink and CrateDB offer graphical user interfaces. You can navigate
+to them by using:
+
+:Apache Flink Dashboard: http://localhost:8081/
+:CrateDB Admin UI: http://localhost:4200/
+
+Notes
+-----
+
+Please read those admonitions carefully in order to optimally prepare your
+system environment to fit the needs of the tutorial.
+
+*Note*
+
+    CrateDB uses a ``mmapfs`` directory by default to store its indices. The
+    default operating system limits on mmap counts is likely to be too low,
+    which may result in out of memory exceptions.
+
+    On Linux, you can increase the limits by running the following command::
+
+        sudo sysctl -w vm.max_map_count=262144
+
+    To set this value permanently, update the ``vm.max_map_count`` setting in
+    ``/etc/sysctl.conf``. To verify after rebooting, run
+    ``sysctl vm.max_map_count``.
+
+*Note*
+
+    When running this tutorial on Windows/WSL2, some upfront configuration is
+    needed.
+
+    1. Install `Docker on Windows`_ and `enable WSL integration`_.
+    2. If your Docker Compose version (check with ``docker-compose --version``)
+       is <1.27.0, please upgrade it by invoking::
+
+           # Install Docker Compose 1.27.0
+           sudo curl -L "https://github.com/docker/compose/releases/download/1.27.0/docker-compose-$(uname -s)-$(uname -m)" \
+               -o /usr/local/bin/docker-compose
+           sudo chmod +x /usr/local/bin/docker-compose
+
+           # Restart your terminal
+
+.. _Docker on Windows: https://desktop.docker.com/win/stable/amd64/Docker%20Desktop%20Installer.exe
+.. _enable WSL integration: https://docs.docker.com/docker-for-windows/wsl/
+
+
+The data
+========
+
+Trip records from NYC taxis.
+
+This dataset includes a subset of trip records completed in NYC taxis during
+2017. The JSON message payload has the following format::
+
+    {
+        "vendor_id": 2,
+        "passenger_count": 1,
+        "trip_distance": 2.84,
+        "fare_amount": 15.5,
+        "tip_amount": 6.0,
+        "tolls_amount": 0.0,
+        "total_amount": 22.3,
+        "pickup_location_id": 142
+    }
+
+The meanings of those fields are:
+
+:vendor_id: A code indicating the vendor
+:passenger_count: The number of passengers in the vehicle
+:trip_distance: The elapsed trip distance in miles
+:fare_amount: The time-and-distance fare calculated by the meter
+:tip_amount: Tip amount
+:tolls_amount: The amount of all tolls paid in trip
+:total_amount: Total amount charged to passengers, ex. cash tips
+:pickup_location_id: Location (lat/lon) where the meter was engaged
+:dropoff_location_id: Location (lat/lon) where the meter was disengaged
+:pickup_datetime: Date & time meter was engaged
+:dropoff_datetime: Date & time meter was disengaged
+
+
+Usage
+=====
+
+In order to run this recipe on your workstation, please follow the
+corresponding guides:
+
+- ``README.Unix.rst``
+- ``README.Windows.rst``
+
+
+----
+
+-- Derived from: ``Building IoT applications with open-source tools.pdf``.
+
+
+.. _Apache Kafka Connector for Flink: https://ci.apache.org/projects/flink/flink-docs-stable/dev/connectors/kafka.html
+.. _CrateDB JDBC driver: https://github.com/crate/crate-jdbc
+.. _JDBC Connector for Flink: https://ci.apache.org/projects/flink/flink-docs-stable/dev/connectors/jdbc.html
+.. _Kafka + Flink\: A Practical, How-To Guide: https://www.ververica.com/blog/kafka-flink-a-practical-how-to

--- a/spikes/kafka-flink/docker-compose.yml
+++ b/spikes/kafka-flink/docker-compose.yml
@@ -1,0 +1,141 @@
+version: "3"
+
+networks:
+  scada-demo:
+    name: scada-demo
+    driver: bridge
+
+services:
+
+  # ---------------
+  # Confluent Kafka
+  # ---------------
+  # https://docs.confluent.io/platform/current/installation/docker/config-reference.html
+  # https://gist.github.com/everpeace/7a317860cab6c7fb39d5b0c13ec2543e
+  # https://github.com/framiere/a-kafka-story/blob/master/step14/docker-compose.yml
+  kafka-zookeeper:
+    image: confluentinc/cp-zookeeper:6.1.1
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      KAFKA_OPTS: -Dzookeeper.4lw.commands.whitelist=ruok
+    networks:
+      - scada-demo
+
+    # Define health check for Zookeeper.
+    healthcheck:
+      # https://github.com/confluentinc/cp-docker-images/issues/827
+      test: ["CMD", "bash", "-c", "echo ruok | nc localhost 2181 | grep imok"]
+      start_period: 3s
+      interval: 2s
+      timeout: 30s
+      retries: 60
+
+  kafka-broker:
+    image: confluentinc/cp-kafka:6.1.1
+    ports:
+      - "9092:9092"
+      - "9094:9094"
+    environment:
+      KAFKA_ZOOKEEPER_CONNECT: kafka-zookeeper:2181
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:9094
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka-broker:9092,EXTERNAL://localhost:9094
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    depends_on:
+      - kafka-zookeeper
+    networks:
+      - scada-demo
+
+    # Define health check for Kafka broker.
+    healthcheck:
+      #test: ps augwwx | egrep "kafka.Kafka"
+      test: ["CMD", "nc", "-vz", "localhost", "9092"]
+      start_period: 3s
+      interval: 0.5s
+      timeout: 30s
+      retries: 60
+
+  # The Kafka schema registry as well as ksqlDB is not needed for this setup.
+  #kafka-schema-registry:
+  #  image: confluentinc/cp-schema-registry:6.1.1
+  #kafka-ksqldb:
+  #  image: confluentinc/cp-ksqldb-server:6.1.1
+
+
+  # ------------
+  # Apache Flink
+  # ------------
+  # https://ci.apache.org/projects/flink/flink-docs-master/docs/deployment/resource-providers/standalone/docker/#flink-with-docker-compose
+  flink-jobmanager:
+    image: flink:1.12
+    ports:
+      - "8081:8081"
+    command: jobmanager
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: flink-jobmanager
+    networks:
+      - scada-demo
+
+    # Define health check for Apache Flink jobmanager.
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://localhost:8081/overview" ]
+      start_period: 3s
+      interval: 0.5s
+      timeout: 30s
+      retries: 60
+
+  flink-taskmanager:
+    image: flink:1.12
+    depends_on:
+      - flink-jobmanager
+    command: taskmanager
+    scale: 1
+    environment:
+      - |
+        FLINK_PROPERTIES=
+        jobmanager.rpc.address: flink-jobmanager
+        taskmanager.numberOfTaskSlots: 2
+    networks:
+      - scada-demo
+
+
+  # -------
+  # CrateDB
+  # -------
+  cratedb:
+    image: crate:4.5.0
+    ports:
+      - "4200:4200"
+      - "5432:5432"
+    environment:
+      CRATE_HEAP_SIZE: 1g
+    networks:
+      - scada-demo
+
+    # Define health check for CrateDB.
+    healthcheck:
+      test: [ "CMD", "curl", "--fail", "http://localhost:4200" ]
+      start_period: 3s
+      interval: 0.5s
+      timeout: 30s
+      retries: 60
+
+
+  # -------
+  # Bundler
+  # -------
+  # Wait for all defined services to be fully available by probing their health
+  # status, even when using `docker-compose up --detach`.
+  # https://marcopeg.com/2019/docker-compose-healthcheck/
+  start-dependencies:
+    image: dadarek/wait-for-dependencies
+    depends_on:
+      kafka-broker:
+        condition: service_healthy
+      flink-jobmanager:
+        condition: service_healthy
+      cratedb:
+        condition: service_healthy

--- a/spikes/kafka-flink/notes.rst
+++ b/spikes/kafka-flink/notes.rst
@@ -1,0 +1,64 @@
+#########################################################
+Notes for Apache Kafka, Apache Flink and CrateDB tutorial
+#########################################################
+
+
+*****
+Kafka
+*****
+
+In order to check the Kafka subsystem, you can use the ``kafkacat`` program to
+submit and receive messages to/from the broker, like::
+
+    # Install program
+    brew install kafkacat
+
+    # Define a message
+    export MESSAGE="The quick brown fox jumps over the lazy dog."
+
+    # Publish message to topic
+    echo $MESSAGE | kafkacat -b localhost:9094 -P -t testdrive
+
+    # Consume messages from topic
+    kafkacat -b localhost:9094 -C -t testdrive -o end
+
+    # Show topics
+    kafkacat -L -b localhost:9094
+
+If you can't install ``kafkacat`` on your machine, you can also use Docker to
+invoke it::
+
+    # Publish message to topic
+    echo $MESSAGE | docker run -i --network=scada-demo edenhill/kafkacat:1.6.0 kafkacat -b kafka-broker -P -t testdrive
+
+    # Consume messages from topic
+    docker run -it --network=scada-demo edenhill/kafkacat:1.6.0 kafkacat -b kafka-broker -C -t testdrive -o end
+
+
+*****
+Flink
+*****
+
+Flink job administration::
+
+    docker run -it --network=scada-demo flink:1.12 \
+        flink list --jobmanager=flink-jobmanager:8081
+
+    docker run -it --network=scada-demo flink:1.12 \
+        flink cancel 873828a960f9ed8a4e71b7ec7e980b0d --jobmanager=flink-jobmanager:8081
+
+
+*******
+CrateDB
+*******
+
+When running low on disk space, the indexes will be made read-only [1]::
+
+    ClusterBlockException[blocked by: [FORBIDDEN/12/index read-only / allow delete (api)];]
+
+In order to make them writable again, invoke::
+
+    http "localhost:4200/_sql?pretty" stmt='ALTER TABLE "taxi_rides" SET ("blocks.read_only_allow_delete" = FALSE)'
+
+
+[1] https://community.crate.io/t/node-in-read-only-mode-after-low-diskspace/166


### PR DESCRIPTION
Hi there,

this is the baseline infrastructure for the tutorial about »_Processing IIoT data with Apache Kafka, Apache Flink and CrateDB_« from the »_Building IoT applications with open-source components_« series of articles.

It gets accompanied by the https://github.com/crate/cratedb-flink-jobs repository.

With kind regards,
Andreas.

cc @carlotasoto
