### PR TITLE
Use new Codecov uploader instead of the Bash Uploader

### DIFF
--- a/.github/workflows/tests-npgsql.yml
+++ b/.github/workflows/tests-npgsql.yml
@@ -63,6 +63,6 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false


### PR DESCRIPTION
Hi.

After the [recent security event at Codecov](https://about.codecov.io/security-update/), they started rolling out their new uploader, see [1]. According to their deprecation plan, they are already conducting scheduled brownouts of the Bash Uploader, starting Sept 1, 2021.

As we are using the corresponding GitHub Action here, see also [2] for further deprecation notices and migration notes.

With kind regards,
Andreas.

[1] https://about.codecov.io/blog/introducing-codecovs-new-uploader/
[2] https://github.com/marketplace/actions/codecov
