### PR TITLE
Kafka/Flink: Add end-to-end test

### DIFF
--- a/.github/workflows/test-kafka-flink.yml
+++ b/.github/workflows/test-kafka-flink.yml
@@ -1,0 +1,42 @@
+name: Apache Kafka, Apache Flink, and CrateDB
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/test-kafka-flink.yml'
+    - 'stacks/kafka-flink/**'
+  pull_request:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/test-kafka-flink.yml'
+    - 'stacks/kafka-flink/**'
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+
+  tests:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ "ubuntu-latest" ]
+
+    name: OS ${{ matrix.os }}
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v3
+
+      - name: Run test program
+        run: |
+          cd stacks/kafka-flink
+          bash test.sh

--- a/stacks/kafka-flink/README.rst
+++ b/stacks/kafka-flink/README.rst
@@ -66,6 +66,32 @@ It uses those connectors and drivers to conclude its job:
 - `CrateDB JDBC driver`_
 
 
+Usage
+=====
+
+In order to run this recipe on your workstation, please follow the
+corresponding guidelines:
+
+- ``README.Unix.rst``
+- ``README.Windows.rst``
+
+There is also a test program ``test.sh`` which exercises those command
+walkthroughs as an end-to-end test. It can be invoked like::
+
+    bash test.sh
+
+Mostly, you want to keep the service containers running, in order to run the
+test progam repeatedly. Use the ``--keepalive`` option for that::
+
+    bash test.sh --keepalive
+
+In order to run specific subcommands/functions defined within the file, invoke,
+for example::
+
+    bash test.sh teardown
+    bash test.sh stop-services
+
+
 Details
 =======
 
@@ -158,16 +184,6 @@ The meanings of those fields are:
 :dropoff_location_id: Location (lat/lon) where the meter was disengaged
 :pickup_datetime: Date & time meter was engaged
 :dropoff_datetime: Date & time meter was disengaged
-
-
-Usage
-=====
-
-In order to run this recipe on your workstation, please follow the
-corresponding guides:
-
-- ``README.Unix.rst``
-- ``README.Windows.rst``
 
 
 ----

--- a/stacks/kafka-flink/docker-compose.yml
+++ b/stacks/kafka-flink/docker-compose.yml
@@ -163,7 +163,15 @@ services:
   create-topic:
     image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
     networks: [scada-demo]
-    command: kafka-topics --bootstrap-server kafka-broker:${PORT_KAFKA_BROKER_INTERNAL} --create --replication-factor 1 --partitions 1 --topic rides
+    command: kafka-topics --bootstrap-server kafka-broker:${PORT_KAFKA_BROKER_INTERNAL} --create --if-not-exists --replication-factor 1 --partitions 1 --topic rides
+    deploy:
+      replicas: 0
+
+  # Delete Kafka topic for publishing messages.
+  delete-topic:
+    image: confluentinc/cp-kafka:${CONFLUENT_VERSION}
+    networks: [scada-demo]
+    command: kafka-topics --bootstrap-server kafka-broker:${PORT_KAFKA_BROKER_INTERNAL} --delete --if-exists --topic rides
     deploy:
       replicas: 0
 

--- a/stacks/kafka-flink/docker-compose.yml
+++ b/stacks/kafka-flink/docker-compose.yml
@@ -155,7 +155,7 @@ services:
   create-table:
     image: westonsteimel/httpie
     networks: [scada-demo]
-    command: http "cratedb:${PORT_CRATEDB_HTTP}/_sql?pretty" stmt='CREATE TABLE "taxi_rides" ("payload" OBJECT(DYNAMIC))'
+    command: http "cratedb:${PORT_CRATEDB_HTTP}/_sql?pretty" stmt='CREATE TABLE "taxi_rides" ("payload" OBJECT(DYNAMIC))' --ignore-stdin
     deploy:
       replicas: 0
 
@@ -189,7 +189,7 @@ services:
   drop-table:
     image: westonsteimel/httpie
     networks: [scada-demo]
-    command: http "cratedb:${PORT_CRATEDB_HTTP}/_sql?pretty" stmt='DROP TABLE "taxi_rides"'
+    command: http "cratedb:${PORT_CRATEDB_HTTP}/_sql?pretty" stmt='DROP TABLE "taxi_rides"' --ignore-stdin
     deploy:
       replicas: 0
 

--- a/stacks/kafka-flink/test.sh
+++ b/stacks/kafka-flink/test.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+
+# =====
+# About
+# =====
+
+# End-to-end test feeding data through a pipeline implemented with Apache Kafka,
+# Apache Flink, and CrateDB. The data source is a file in NDJSON format, the
+# data sink is a database table in CrateDB.
+
+
+# ============
+# Main program
+# ============
+
+set -e
+
+
+# ----------------------------
+# Infrastructure and resources
+# ----------------------------
+
+function start-services() {
+  title "Starting services"
+  docker compose up --detach
+}
+
+function stop-services() {
+  title "Stopping services"
+  docker compose down --remove-orphans
+}
+
+function setup() {
+  title "Creating CrateDB table"
+  docker compose run --rm create-table
+  title "Creating Kafka topic"
+  docker compose run --rm create-topic
+}
+
+function teardown() {
+  title "Cancelling Flink jobs"
+  flink-cancel-all-jobs
+  title "Deleting Kafka topic"
+  docker compose run --rm --no-TTY delete-topic
+  title "Dropping CrateDB table"
+  docker compose run --rm drop-table
+}
+
+
+# --------
+# Pipeline
+# --------
+
+function invoke-job() {
+
+  # Delete downloaded JAR file upfront.
+  # TODO: This is a little bit hard-coded. Improve!
+  #rm cratedb-flink-jobs-*.jar || true
+
+  # Acquire Flink job JAR file.
+  if ! test -f cratedb-flink-jobs-*.jar; then
+    title "Acquiring Flink job JAR file"
+    docker compose run --rm --volume=$(pwd):/src download-job
+  fi
+
+  # Submit and invoke Flink job.
+  title "Submitting job to Flink"
+  docker compose run --rm --volume=$(pwd):/src submit-job
+
+  # List running jobs.
+  title "Listing running Flink jobs"
+  docker compose run --rm list-jobs
+}
+
+function feed-data() {
+
+  if [[ ! -f nyc-yellow-taxi-2017-subset.ndjson ]]; then
+
+    title "Acquiring NDJSON data"
+
+    # Acquire NYC Taxi 2017 dataset in JSON format (~90 MB).
+    wget --no-clobber --continue https://gist.githubusercontent.com/kovrus/328ba1b041dfbd89e55967291ba6e074/raw/7818724cb64a5d283db7f815737c9e198a22bee4/nyc-yellow-taxi-2017.tar.gz
+
+    # Extract archive.
+    tar -xvf nyc-yellow-taxi-2017.tar.gz
+
+    # Create a subset of the data (5000 records) for concluding the first steps.
+    cat nyc-yellow-taxi-2017.json | head -n 5000 > nyc-yellow-taxi-2017-subset.ndjson
+
+  fi
+
+  # Publish data to the Kafka topic.
+  title "Publishing NDJSON data to Kafka topic"
+  cat nyc-yellow-taxi-2017-subset.ndjson | docker compose run --rm --no-TTY publish-data
+  echo
+
+  # Wait a bit for the data to transfer and converge successfully.
+  sleep 1
+}
+
+
+# ---------
+# Data sink
+# ---------
+
+function display-data() {
+
+  title "Displaying data in CrateDB"
+
+  docker compose run --rm httpie \
+    http "cratedb:4200/_sql?pretty" stmt='REFRESH TABLE "taxi_rides";' --ignore-stdin > /dev/null
+
+  docker compose run --rm httpie \
+    http "cratedb:4200/_sql?pretty" stmt='SELECT * FROM "taxi_rides" LIMIT 5;'
+
+  docker compose run --rm httpie \
+    http "cratedb:4200/_sql?pretty" stmt='SELECT COUNT(*) FROM "taxi_rides";'
+
+}
+
+function verify-data() {
+  title "Verifying data in CrateDB"
+  size_reference=5000
+  size_actual=$(
+    docker compose run --rm httpie \
+      http "cratedb:4200/_sql?pretty" stmt='SELECT COUNT(*) FROM "taxi_rides";' --ignore-stdin \
+    | jq .rows[0][0]
+  )
+  if [[ ${size_actual} = ${size_reference} ]]; then
+    echo -e "${BGREEN}SUCCESS: Database table contains expected number of ${size_reference} records.${NC}"
+  else
+    echo -e "${BRED}ERROR:   Expected database table to contain ${size_reference} records, but it contains ${size_actual} records.${NC}"
+    exit 2
+  fi
+}
+
+
+# ------
+# Recipe
+# ------
+
+function main() {
+
+  # Start services and setup resources.
+  start-services
+  setup
+
+  # Acquire and submit Flink job, feed data to Kafka topic,
+  # and verify data has been stored into CrateDB.
+  invoke-job
+  feed-data
+  display-data
+  verify-data
+
+  # Clean up resources.
+  teardown
+
+  # Tear down only when `--keepalive` option has not been given.
+  test -z "${KEEPALIVE}" && stop-services
+}
+
+function start_subcommand() {
+  if test -n "${SUBCOMMAND}"; then
+    ${SUBCOMMAND}
+    exit
+  fi
+}
+
+function start() {
+  read_options
+  init_colors
+  start_subcommand
+  main
+}
+
+
+# =================
+# Utility functions
+# =================
+
+# https://dustymabe.com/2013/05/17/easy-getopt-for-a-bash-script/
+options=$(getopt --options k --longoptions keepalive -- "$@")
+function read_options() {
+
+  # Call getopt to validate the provided input.
+  [ $? -eq 0 ] || {
+      echo "Incorrect options provided"
+      exit 1
+  }
+  eval set -- "$options"
+  while true; do
+      case "$1" in
+      -k)
+          KEEPALIVE=true
+          shift
+          continue
+          ;;
+      --keepalive)
+          KEEPALIVE=true
+          shift
+          continue
+          ;;
+      --)
+          shift
+          break
+          ;;
+      esac
+      shift
+  done
+  SUBCOMMAND=$1
+
+}
+
+function flink-get-job-ids() {
+  source .env
+  jobids=$(
+    curl --silent http://localhost:${PORT_FLINK_JOBMANAGER}/jobs/overview \
+    | jq -r '.jobs[] | select(.state == "RUNNING").jid'
+  )
+  echo $jobids
+}
+
+function flink-cancel-job() {
+  jobid=$1
+  echo "Cancelling job $jobid"
+  source .env
+  docker run --rm --network=scada-demo flink:${FLINK_VERSION} \
+    flink cancel ${jobid} --jobmanager=flink-jobmanager:${PORT_FLINK_JOBMANAGER}
+}
+
+function flink-cancel-all-jobs() {
+  for jobid in $(flink-get-job-ids); do
+    flink-cancel-job $jobid
+  done
+}
+
+function title() {
+  text=$1
+  len=${#text}
+  guard=$(printf "%${len}s" | sed 's/ /=/g')
+  echo
+  echo ${guard}
+  echo -e "${BYELLOW}${text}${NC}"
+  echo ${guard}
+}
+
+function init_colors() {
+  # Reset
+  NC='\033[0m'
+
+  # Regular
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'
+  PURPLE='\033[0;35m'
+  CYAN='\033[0;36m'
+  WHITE='\033[0;37m'
+
+  # Bold
+  BBLACK='\033[1;30m'
+  BRED='\033[1;31m'
+  BGREEN='\033[1;32m'
+  BYELLOW='\033[1;33m'
+  BBLUE='\033[1;34m'
+  BPURPLE='\033[1;35m'
+  BCYAN='\033[1;36m'
+  BWHITE='\033[1;37m'
+}
+
+
+start

--- a/stacks/kafka-flink/test.sh
+++ b/stacks/kafka-flink/test.sh
@@ -111,10 +111,10 @@ function display-data() {
     http "cratedb:4200/_sql?pretty" stmt='REFRESH TABLE "taxi_rides";' --ignore-stdin > /dev/null
 
   docker compose run --rm httpie \
-    http "cratedb:4200/_sql?pretty" stmt='SELECT * FROM "taxi_rides" LIMIT 5;'
+    http "cratedb:4200/_sql?pretty" stmt='SELECT * FROM "taxi_rides" LIMIT 5;' --ignore-stdin
 
   docker compose run --rm httpie \
-    http "cratedb:4200/_sql?pretty" stmt='SELECT COUNT(*) FROM "taxi_rides";'
+    http "cratedb:4200/_sql?pretty" stmt='SELECT COUNT(*) FROM "taxi_rides";' --ignore-stdin
 
 }
 


### PR DESCRIPTION
Hi again,

as promised at GH-20, this patch adds a basic end-to-end test for the Kafka/Flink/CrateDB stack, also running it on CI/GHA. I am sad that it is a Bash script, but this is still the most compact yet coherent representation of the recipe. The outcome will be a description like this, in the error case with an exitcode != 0.

```
=========================
Verifying data in CrateDB
=========================
SUCCESS: Database table contains expected number of 5000 records.
```

```
=========================
Verifying data in CrateDB
=========================
ERROR:   Expected database table to contain 5000 records, but it contains 0 records.
```

With kind regards,
Andreas.
