### PR TITLE
Java/JDBC: Adjustments to also demonstrate usage with CrateDB Cloud

### DIFF
--- a/by-language/java-jdbc/BasicPostgresCrateDB.java
+++ b/by-language/java-jdbc/BasicPostgresCrateDB.java
@@ -5,50 +5,70 @@ import java.sql.DriverManager;
 import java.sql.ResultSetMetaData;
 import java.util.Locale;
 import java.util.Properties;
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.JCommander;
 
 public class BasicPostgresCrateDB {
 
+    @Parameter(names = {"--dburl", "-d"}, description = "Database URL")
+    String dburl;
+    @Parameter(names = {"--user", "-u"}, description = "Username")
+    String user = "crate";
+    @Parameter(names = {"--password", "-p"}, description = "Password")
+    String password = "";
+
+    @Parameter(names = "--help", help = true, description = "Display this page")
+    private boolean help;
+
     public static final int SO_RCVBUF = 1024 * 1024; // 1 MB
-    public static final int MAX_BATCH_SIZE = 20000;
+    public static final int MAX_BATCH_SIZE = 10000;
     public static final int QUERY_EXECUTION_TIMEOUT_SECS = 60;
 
+    public static void main(String ... argv) throws Exception {
 
-    public static void main(String[] args) throws Exception {
+        BasicPostgresCrateDB main = new BasicPostgresCrateDB();
+        JCommander jc = JCommander.newBuilder()
+                .addObject(main)
+                .build();
+        jc.setProgramName("cratedb-jdbc-example");
+        jc.parse(argv);
+        int exitcode = main.run(jc);
+        System.exit(exitcode);
+    }
+    public int run(JCommander jc) throws Exception {
+        /*
+         * Connect to CrateDB and query `sys.summits` table.
+         * https://jdbc.postgresql.org/documentation/head/connect.html
+         */
+        if (help) {
+            jc.usage();
+            return 0;
+        }
 
-        // Create schema and insert data:
-        //
-        // psql postgres://crate@localhost:5432/
-        //
-        // CREATE TABLE testdrive (id INT PRIMARY KEY, data TEXT);
-        // INSERT INTO testdrive VALUES (0, 'zero'), (1, 'one'), (2, 'two');
-
-        // String connectionUrl = "jdbc:postgresql://localhost:5432/";
-        // String connectionUrl = "jdbc:crate://localhost:5432/";
-        String connectionUrl = args[0];
+        String connectionUrl = dburl;
 
         Properties connectionProps = new Properties();
-        // https://jdbc.postgresql.org/documentation/head/connect.html
-        connectionProps.put("user", "crate");
-        connectionProps.put("password", "");
-        connectionProps.put("ssl", false);
+        connectionProps.put("user", user);
+        connectionProps.put("password", password);
+        //connectionProps.put("ssl", "true");
         connectionProps.put("recvBufferSize", SO_RCVBUF);
         connectionProps.put("defaultRowFetchSize", MAX_BATCH_SIZE);
         connectionProps.put("loginTimeout", 5); // seconds, fail fast-ish
         connectionProps.put("socketTimeout", QUERY_EXECUTION_TIMEOUT_SECS);
         connectionProps.put("tcpKeepAlive", true);
 
-
         try (Connection sqlConnection = DriverManager.getConnection(connectionUrl, connectionProps)) {
             sqlConnection.setAutoCommit(true);
             if (sqlConnection.isClosed()) {
-                System.out.println("Connection is not valid");
-                return;
+                System.out.println("ERROR: Unable to open connection to database");
+                return 1;
             }
-            try(Statement stmt = sqlConnection.createStatement()) {
-                boolean checkResults = stmt.execute("select * from testdrive");
+            try (Statement stmt = sqlConnection.createStatement()) {
+                boolean checkResults = stmt.execute("SELECT * FROM sys.summits LIMIT 3;");
                 if (checkResults) {
                     ResultSet rs = stmt.getResultSet();
                     while (rs.next()) {
+                        System.out.printf(Locale.ENGLISH, "> row %d\n", rs.getRow());
                         ResultSetMetaData metaData = rs.getMetaData();
                         int columnCount = metaData.getColumnCount();
                         for (int i = 1; i <= columnCount; i++) {
@@ -60,8 +80,16 @@ public class BasicPostgresCrateDB {
                                     rs.getObject(i));
                         }
                     }
+                } else {
+                    System.out.println("WARNING: Result is empty");
+                    return 1;
                 }
             }
+            sqlConnection.close();
+        } catch (Exception ex) {
+            System.out.println("ERROR: " + ex);
+            return 1;
         }
+        return 0;
     }
 }

--- a/by-language/java-jdbc/README.rst
+++ b/by-language/java-jdbc/README.rst
@@ -1,8 +1,8 @@
 .. highlight: console
 
-##################################################
-Basic example for connecting to CrateDB using JDBC
-##################################################
+####################################################################
+Basic example for connecting to CrateDB and CrateDB Cloud using JDBC
+####################################################################
 
 
 *****
@@ -11,7 +11,7 @@ About
 
 This is a basic example program derived from `How can I connect to CrateDB using JDBC?`_.
 It demonstrates CrateDB's `PostgreSQL wire protocol`_ compatibility by exercising a basic
-example using both the vanilla `PgJDBC Driver`_ and the `CrateDB JDBC Driver`_.
+example using both the vanilla `PostgreSQL JDBC Driver`_ and the `CrateDB legacy JDBC driver`_.
 
 For further information, please also visit the `CrateDB clients and tools`_ page.
 Because CrateDB only supports (implicitly created) `table schemas`_ instead of databases,
@@ -22,40 +22,47 @@ it makes sense to also have a look at the `PostgreSQL documentation about schema
 Usage
 *****
 
-To invoke a CrateDB instance for evaluation purposes, run::
+To start a CrateDB instance on your machine for evaluation purposes, invoke::
 
-    docker run -it --rm --publish=4200:4200 --publish=5432:5432 crate:5.1.1
-
-Create schema and insert data::
-
-    psql postgres://crate@localhost:5432/doc
-
-.. code-block:: sql
-
-    CREATE TABLE testdrive (id INT PRIMARY KEY, data TEXT);
-    INSERT INTO testdrive VALUES (0, 'zero'), (1, 'one'), (2, 'two');
+    docker run -it --rm --publish=4200:4200 --publish=5432:5432 crate
 
 Invoke example program::
 
+    # Acquire sources.
     git clone https://github.com/crate/cratedb-examples
     cd cratedb-examples/by-language/java-jdbc
 
-    # Use vanilla PgJDBC driver
-    mvn install exec:java -Dexec.args="'jdbc:postgresql://localhost:5432/'"
+    # Download dependencies and build program.
+    mvn install
 
-    # Use CrateDB JDBC driver
-    mvn install exec:java -Dexec.args="'jdbc:crate://localhost:5432/'"
+    # Display program options.
+    mvn exec:java -Dexec.args="--help"
+
+Connect to instance on ``localhost``::
+
+    # Use vanilla PostgreSQL JDBC driver.
+    mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://localhost:5432/'"
+
+    # Use CrateDB legacy JDBC driver.
+    mvn exec:java -Dexec.args="--dburl 'jdbc:crate://localhost:5432/'"
+
+Connect to CrateDB Cloud::
+
+    # Use vanilla PostgreSQL JDBC driver.
+    mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://example.aks1.westeurope.azure.cratedb.net:5432/' --user 'admin' --password '<PASSWORD>'"
+
+    # Use CrateDB legacy JDBC driver.
+    mvn exec:java -Dexec.args="--dburl 'jdbc:crate://example.aks1.westeurope.azure.cratedb.net:5432/' --user 'admin' --password '<PASSWORD>'"
 
 In order to clean the build artefacts, invoke::
 
     mvn clean
 
 
-
 .. _CrateDB clients and tools: https://crate.io/docs/crate/clients-tools/
-.. _CrateDB JDBC Driver: https://github.com/crate/crate-jdbc
+.. _CrateDB legacy JDBC driver: https://github.com/crate/crate-jdbc
 .. _How can I connect to CrateDB using JDBC?: https://community.crate.io/t/how-can-i-connect-to-cratedb-using-jdbc/400
 .. _PostgreSQL documentation about schemas: https://www.postgresql.org/docs/current/ddl-schemas.html
+.. _PostgreSQL JDBC Driver: https://jdbc.postgresql.org/
 .. _PostgreSQL wire protocol: https://crate.io/docs/reference/en/latest/protocols/postgres.html
-.. _PgJDBC Driver: https://jdbc.postgresql.org/
 .. _table schemas: https://crate.io/docs/crate/reference/en/4.6/general/ddl/create-table.html#schemas

--- a/by-language/java-jdbc/pom.xml
+++ b/by-language/java-jdbc/pom.xml
@@ -6,15 +6,10 @@
 
     <groupId>crate.io</groupId>
     <artifactId>cratedb-jdbc-example</artifactId>
-    <version>0.1.0</version>
+    <version>0.2.0</version>
 
-    <name>Basic example for connecting to CrateDB using JDBC</name>
-    <url>https://github.com/crate/cratedb-examples</url>
-
-    <properties>
-        <pgjdbc.version>42.2.23</pgjdbc.version>
-        <crate-jdbc.version>2.6.0</crate-jdbc.version>
-    </properties>
+    <name>Basic example for connecting to CrateDB and CrateDB Cloud using JDBC</name>
+    <url>https://github.com/crate/cratedb-examples/tree/main/by-language/java-jdbc</url>
 
     <repositories>
         <repository>
@@ -33,13 +28,19 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${pgjdbc.version}</version>
+            <version>42.6.0</version>
         </dependency>
 
         <dependency>
             <groupId>io.crate</groupId>
             <artifactId>crate-jdbc</artifactId>
-            <version>${crate-jdbc.version}</version>
+            <version>2.6.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+            <version>1.82</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Hi there,

this patch aims to improve the canonical Java/JDBC example to also cover demonstrating usage with CrateDB Cloud.

- Add [JCommander](https://jcommander.org/) for command line argument parsing
- Skip provisioning a database schema, query `sys.summits` instead
- Improve error handling

With kind regards,
Andreas.
