### PR TITLE
Modernize kafka-flink-cratedb job to run with flink 1.16.1

### DIFF
--- a/stacks/kafka-flink/.env
+++ b/stacks/kafka-flink/.env
@@ -1,7 +1,7 @@
 # Software component versions.
-CONFLUENT_VERSION=6.1.9
+CONFLUENT_VERSION=7.3.2
 CRATEDB_VERSION=5.2.2
-FLINK_VERSION=1.13
+FLINK_VERSION=1.16.1
 KCAT_VERSION=1.7.1
 
 # TCP ports in use.
@@ -14,6 +14,6 @@ PORT_KAFKA_ZOOKEEPER=2181
 
 # Options for acquiring the Flink job JAR file.
 # https://github.com/crate/cratedb-flink-jobs
-FLINK_JOB_JAR_VERSION=0.2
+FLINK_JOB_JAR_VERSION=0.3dev1
 FLINK_JOB_JAR_FILE=cratedb-flink-jobs-${FLINK_JOB_JAR_VERSION}.jar
-FLINK_JOB_JAR_URL=https://github.com/crate/cratedb-flink-jobs/releases/download/${FLINK_JOB_JAR_VERSION}/${FLINK_JOB_JAR_FILE}
+FLINK_JOB_JAR_URL=https://github.com/crate-workbench/jarfiles/raw/main/${FLINK_JOB_JAR_FILE}

--- a/stacks/kafka-flink/README.rst
+++ b/stacks/kafka-flink/README.rst
@@ -42,8 +42,8 @@ can be used as a blueprint for building own applications.
 
 The following versions of software components are used:
 
-- Apache Flink 1.13
-- Confluent Kafka 6.1.9
+- Apache Flink 1.16
+- Confluent Kafka 7.3
 - CrateDB 5.2.2
 
 Flink jobs have been tested using those software component versions:

--- a/stacks/kafka-flink/docker-compose.yml
+++ b/stacks/kafka-flink/docker-compose.yml
@@ -180,8 +180,7 @@ services:
     image: apteno/alpine-jq
     networks: [scada-demo]
     command: >
-      wget https://github.com/crate/cratedb-flink-jobs/releases/download/${FLINK_JOB_JAR_VERSION}/${FLINK_JOB_JAR_FILE}
-        --output-document /src/${FLINK_JOB_JAR_FILE}
+      wget ${FLINK_JOB_JAR_URL} --output-document /src/${FLINK_JOB_JAR_FILE}
     deploy:
       replicas: 0
 

--- a/stacks/kafka-flink/test.sh
+++ b/stacks/kafka-flink/test.sh
@@ -53,12 +53,14 @@ function teardown() {
 
 function invoke-job() {
 
+  source .env
+
   # Delete downloaded JAR file upfront.
   # TODO: This is a little bit hard-coded. Improve!
   #rm cratedb-flink-jobs-*.jar || true
 
   # Acquire Flink job JAR file.
-  if ! test -f cratedb-flink-jobs-*.jar; then
+  if ! test -f "${FLINK_JOB_JAR_FILE}"; then
     title "Acquiring Flink job JAR file"
     docker compose run --rm --volume=$(pwd):/src download-job
   fi


### PR DESCRIPTION
Kafka/Flink: Properly use pre-release `cratedb-flink-jobs-0.3dev1`
based on https://github.com/crate/cratedb-flink-jobs/tree/mt/update-flink-jobs
