### PR TITLE
Use new release of cratedb-flink-jobs

### DIFF
--- a/stacks/kafka-flink/.env
+++ b/stacks/kafka-flink/.env
@@ -14,6 +14,6 @@ PORT_KAFKA_ZOOKEEPER=2181
 
 # Options for acquiring the Flink job JAR file.
 # https://github.com/crate/cratedb-flink-jobs
-FLINK_JOB_JAR_VERSION=0.3dev1
+FLINK_JOB_JAR_VERSION=0.3
 FLINK_JOB_JAR_FILE=cratedb-flink-jobs-${FLINK_JOB_JAR_VERSION}.jar
-FLINK_JOB_JAR_URL=https://github.com/crate-workbench/jarfiles/raw/main/${FLINK_JOB_JAR_FILE}
+FLINK_JOB_JAR_URL=https://github.com/crate/cratedb-flink-jobs/releases/download/${FLINK_JOB_JAR_VERSION}/${FLINK_JOB_JAR_FILE}


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Use the new `0.3.` release instead of the temp 0.3-dev1.

Fixes: https://github.com/crate/cratedb-examples/issues/6


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
