### PR TITLE
CI: Improve configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,16 @@
 version: 2
 updates:
 
+  # Check GitHub Actions
+  # Workflow files stored in the default location of `.github/workflows`
+  - directory: "/"
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "monthly"
+
+
+  # Check individual projects in subfolders.
+
   - directory: "/by-language/csharp-npgsql" # Location of package manifests
     package-ecosystem: "nuget" # See documentation for possible values
     schedule:

--- a/.github/workflows/test-java-jooq.yml
+++ b/.github/workflows/test-java-jooq.yml
@@ -1,0 +1,55 @@
+name: Java jOOQ
+on:
+
+  pull_request:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/test-java-jooq.yml'
+    - 'by-language/java-jooq/**'
+  push:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/test-java-jooq.yml'
+    - 'by-language/java-jooq/**'
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  test:
+    name: "CrateDB: ${{ matrix.cratedb-version }}
+     on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ "ubuntu-latest" ]
+        cratedb-version: [ "nightly" ]
+
+    services:
+      cratedb:
+        image: crate/crate:nightly
+        ports:
+          - 4200:4200
+          - 5432:5432
+
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          cache: "gradle"
+
+      - name: Run software tests
+        run: |
+          cd by-language/java-jooq
+          ./gradlew check

--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -1,4 +1,4 @@
-name: Npgsql Tests
+name: C# Npgsql
 
 on:
 


### PR DESCRIPTION
In order to accomodate recent Dependabot notices, this improves the test coverage beforehand.

- Rename npgsql workflow file
- Run tests for `java-jooq` example
- Enable Dependabot to check GitHub Action packages for freshness