### PR TITLE
CI: A few adjustments, mostly about scheduling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,38 +8,45 @@ updates:
 
   # Check GitHub Actions
   # Workflow files stored in the default location of `.github/workflows`
+
+  # Root.
+
   - directory: "/"
     package-ecosystem: "github-actions"
     schedule:
       interval: "monthly"
 
+  - directory: "/"
+    package-ecosystem: "pip"
+    schedule:
+      interval: "weekly"
 
-  # Check individual projects in sub-folders.
+  # Languages.
 
   - directory: "/by-language/csharp-npgsql"
     package-ecosystem: "nuget"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - directory: "/by-language/java-jdbc"
     package-ecosystem: "maven"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - directory: "/by-language/java-jooq"
     package-ecosystem: "gradle"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - directory: "/by-language/php-amphp"
     package-ecosystem: "composer"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - directory: "/by-language/php-pdo"
     package-ecosystem: "composer"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
 
   - directory: "/by-language/python-sqlalchemy"
     package-ecosystem: "pip"
@@ -49,7 +56,8 @@ updates:
   - directory: "/by-language/ruby"
     package-ecosystem: "bundler"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+
   # Frameworks.
 
   - directory: "/framework/langchain"
@@ -62,8 +70,9 @@ updates:
     schedule:
       interval: "weekly"
 
+  # Testing.
 
   - directory: "/testing/testcontainers/java"
     package-ecosystem: "gradle"
     schedule:
-      interval: "monthly"
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -50,6 +50,18 @@ updates:
     package-ecosystem: "bundler"
     schedule:
       interval: "monthly"
+  # Frameworks.
+
+  - directory: "/framework/langchain"
+    package-ecosystem: "pip"
+    schedule:
+      interval: "weekly"
+
+  - directory: "/framework/mlflow"
+    package-ecosystem: "pip"
+    schedule:
+      interval: "weekly"
+
 
   - directory: "/testing/testcontainers/java"
     package-ecosystem: "gradle"

--- a/.github/workflows/test-java-jdbc.yml
+++ b/.github/workflows/test-java-jdbc.yml
@@ -1,6 +1,6 @@
 name: Java JDBC
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/test-java-jdbc.yml
+++ b/.github/workflows/test-java-jdbc.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/test-java-jooq.yml
+++ b/.github/workflows/test-java-jooq.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/test-java-jooq.yml
+++ b/.github/workflows/test-java-jooq.yml
@@ -1,6 +1,6 @@
 name: Java jOOQ
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/test-kafka-flink.yml
+++ b/.github/workflows/test-kafka-flink.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/test-kafka-flink.yml
+++ b/.github/workflows/test-kafka-flink.yml
@@ -1,13 +1,13 @@
 name: Apache Kafka, Apache Flink, and CrateDB
 
 on:
-  push:
-    branches: [ main ]
+  pull_request:
+    branches: ~
     paths:
     - '.github/workflows/test-kafka-flink.yml'
     - 'stacks/kafka-flink/**'
     - 'requirements.txt'
-  pull_request:
+  push:
     branches: [ main ]
     paths:
     - '.github/workflows/test-kafka-flink.yml'

--- a/.github/workflows/test-langchain.yml
+++ b/.github/workflows/test-langchain.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/test-langchain.yml
+++ b/.github/workflows/test-langchain.yml
@@ -1,6 +1,6 @@
 name: LangChain
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -19,7 +19,7 @@ on:
 
   # Run job each night after CrateDB nightly has been published.
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
 
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:

--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -1,16 +1,14 @@
 name: C# Npgsql
 
 on:
-
-  # Run job only on changes to specific directories.
-  push:
-    branches: [ main ]
+  pull_request:
+    branches: ~
     paths:
     - '.github/workflows/*npgsql*'
     - 'by-language/csharp-npgsql/**'
     - 'requirements.txt'
-  pull_request:
-    branches: ~
+  push:
+    branches: [ main ]
     paths:
     - '.github/workflows/*npgsql*'
     - 'by-language/csharp-npgsql/**'

--- a/.github/workflows/test-php-amphp.yml
+++ b/.github/workflows/test-php-amphp.yml
@@ -1,6 +1,6 @@
 name: PHP AMPHP
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/test-php-amphp.yml
+++ b/.github/workflows/test-php-amphp.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/test-php-pdo.yml
+++ b/.github/workflows/test-php-pdo.yml
@@ -1,6 +1,6 @@
 name: PHP PDO
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/test-php-pdo.yml
+++ b/.github/workflows/test-php-pdo.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/test-python-sqlalchemy.yml
+++ b/.github/workflows/test-python-sqlalchemy.yml
@@ -1,6 +1,6 @@
 name: Python SQLAlchemy
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/test-python-sqlalchemy.yml
+++ b/.github/workflows/test-python-sqlalchemy.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -1,6 +1,6 @@
 name: Ruby
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true

--- a/.github/workflows/testcontainers-java.yml
+++ b/.github/workflows/testcontainers-java.yml
@@ -1,6 +1,6 @@
 name: Testcontainers for Java
-on:
 
+on:
   pull_request:
     branches: ~
     paths:

--- a/.github/workflows/testcontainers-java.yml
+++ b/.github/workflows/testcontainers-java.yml
@@ -17,6 +17,10 @@ on:
   # Allow job to be triggered manually.
   workflow_dispatch:
 
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:
   cancel-in-progress: true


### PR DESCRIPTION
## About

- Dependabot: Add `/framework/{langchain,mlflow}` directories
- Dependabot: Schedule to run weekly
- Reformat `on:` / trigger section
- Schedule all established jobs to run each night. _Only when doing it this way, we will have a chance of getting notified
properly about any changes / regressions. Otherwise, they will go unnoticed, because, well, there is no other activity on the CI job._