### PR TITLE
CI: Update language versions

### DIFF
--- a/.github/workflows/test-java-jdbc.yml
+++ b/.github/workflows/test-java-jdbc.yml
@@ -28,13 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
+     Java: ${{ matrix.java-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
-        cratedb-version: [ "nightly" ]
+        os: [ 'ubuntu-latest' ]
+        java-version: [ '11', '17' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:
@@ -65,7 +69,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: ${{ matrix.java-version }}
           cache: "maven"
 
       - name: Validate by-language/java-jdbc

--- a/.github/workflows/test-java-jdbc.yml
+++ b/.github/workflows/test-java-jdbc.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        java-version: [ '11', '17' ]
+        java-version: [ '11', '17', '21' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/test-java-jooq.yml
+++ b/.github/workflows/test-java-jooq.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        java-version: [ '17' ]
+        java-version: [ '17', '21' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/test-java-jooq.yml
+++ b/.github/workflows/test-java-jooq.yml
@@ -28,13 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
+     Java: ${{ matrix.java-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
-        cratedb-version: [ "nightly" ]
+        os: [ 'ubuntu-latest' ]
+        java-version: [ '11', '17' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:
@@ -65,7 +69,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: ${{ matrix.java-version }}
           cache: "gradle"
 
       - name: Validate by-language/java-jooq

--- a/.github/workflows/test-java-jooq.yml
+++ b/.github/workflows/test-java-jooq.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        java-version: [ '11', '17' ]
+        java-version: [ '17' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/test-langchain.yml
+++ b/.github/workflows/test-langchain.yml
@@ -28,16 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
      Python: ${{ matrix.python-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
-        cratedb-version: [ "nightly" ]
-        python-version: [ "3.11" ]
+        os: [ 'ubuntu-latest' ]
+        python-version: [ '3.11', '3.12' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:

--- a/.github/workflows/test-langchain.yml
+++ b/.github/workflows/test-langchain.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11', '3.12' ]
+        python-version: [ '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -41,10 +41,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]  # , macos-latest
-        dotnet-version: ['5.0.x', '6.0.x', '7.0.x']
-        cratedb-version: ['nightly']
-        npgsql-version: ['6.0.9', '7.0.6']
+        os: [ 'ubuntu-latest' ]
+        dotnet-version: [ '5.0.x', '6.0.x', '7.0.x' ]
+        cratedb-version: [ 'nightly' ]
+        npgsql-version: [ '6.0.10', '7.0.6' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
@@ -55,6 +55,7 @@ jobs:
           - 5432:5432
 
     steps:
+
       - name: Acquire sources
         uses: actions/checkout@v4
 

--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -33,8 +33,8 @@ defaults:
 jobs:
   test:
     name: "
-     Npgsql: ${{ matrix.npgsql-version }}
      .NET: ${{ matrix.dotnet-version }}
+     Npgsql: ${{ matrix.npgsql-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -43,8 +43,8 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         dotnet-version: [ '5.0.x', '6.0.x', '7.0.x' ]
-        cratedb-version: [ 'nightly' ]
         npgsql-version: [ '6.0.10', '7.0.6' ]
+        cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:

--- a/.github/workflows/test-php-amphp.yml
+++ b/.github/workflows/test-php-amphp.yml
@@ -28,16 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
      PHP: ${{ matrix.php-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
-        cratedb-version: [ "nightly" ]
-        php-version: [ "7.4", "8.2" ]
+        os: [ 'ubuntu-latest' ]
+        php-version: [ '7.4', '8.2', '8.3' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:

--- a/.github/workflows/test-php-pdo.yml
+++ b/.github/workflows/test-php-pdo.yml
@@ -28,16 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
      PHP: ${{ matrix.php-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
-        cratedb-version: [ "nightly" ]
-        php-version: [ "7.4", "8.2" ]
+        os: [ 'ubuntu-latest' ]
+        php-version: [ '7.4', '8.2', '8.3' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:

--- a/.github/workflows/test-python-sqlalchemy.yml
+++ b/.github/workflows/test-python-sqlalchemy.yml
@@ -28,16 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
      Python: ${{ matrix.python-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
-        cratedb-version: [ "nightly" ]
-        python-version: [ "3.11" ]
+        os: [ 'ubuntu-latest' ]
+        python-version: [ '3.11', '3.12' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -28,16 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
      Ruby: ${{ matrix.ruby-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
-        cratedb-version: [ "nightly" ]
-        ruby-version: [ "2.7", "3.0", "3.1", "truffleruby" ]
+        os: [ 'ubuntu-latest' ]
+        ruby-version: [ '2.7', '3.0', '3.1', '3.2', 'truffleruby', 'truffleruby+graalvm' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:

--- a/.github/workflows/testcontainers-java.yml
+++ b/.github/workflows/testcontainers-java.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        java-version: [ '11', '17' ]
+        java-version: [ '11', '17', '21' ]
         cratedb-version: [ 'nightly' ]
 
     steps:

--- a/.github/workflows/testcontainers-java.yml
+++ b/.github/workflows/testcontainers-java.yml
@@ -28,12 +28,17 @@ concurrency:
 
 jobs:
   test:
-    name: "CrateDB: ${{ matrix.cratedb-version }}
+    name: "
+     Java: ${{ matrix.java-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: [ "ubuntu-latest" ]
+        os: [ 'ubuntu-latest' ]
+        java-version: [ '11', '17' ]
+        cratedb-version: [ 'nightly' ]
 
     steps:
 
@@ -57,7 +62,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "17"
+          java-version: ${{ matrix.java-version }}
           cache: "gradle"
 
       - name: Validate testing/testcontainers/java

--- a/by-language/python-sqlalchemy/insert_dask.py
+++ b/by-language/python-sqlalchemy/insert_dask.py
@@ -14,12 +14,10 @@ Usage
 
 """
 import dask.dataframe as dd
-import pkg_resources
 from dask.diagnostics import ProgressBar
 from pandas._testing import makeTimeDataFrame
 from crate.client.sqlalchemy.support import insert_bulk
 
-pkg_resources.require("sqlalchemy>=2.0")
 
 DBURI = "crate://localhost:4200"
 

--- a/by-language/python-sqlalchemy/insert_pandas.py
+++ b/by-language/python-sqlalchemy/insert_pandas.py
@@ -48,7 +48,6 @@ import logging
 
 import click
 import colorlog
-import pkg_resources
 import sqlalchemy as sa
 from colorlog.escape_codes import escape_codes
 from pandas._testing import makeTimeDataFrame
@@ -57,7 +56,6 @@ from crate.client.sqlalchemy.support import insert_bulk
 
 logger = logging.getLogger(__name__)
 
-pkg_resources.require("sqlalchemy>=2.0")
 
 SQLALCHEMY_LOGGING = True
 


### PR DESCRIPTION
## About

Bump a few language versions on CI, where possible.

- Java 11 vs. 17
- PHP 8.3
- Python 3.12
- Ruby 3.2

/cc @hammerhead, @hlcianfagna, @karynzv, @WalBeh 