### PR TITLE
CI: Update to ngr 0.0.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,11 @@ Testing
 The repository includes an universal test runner, which can be used to invoke
 test suites of different languages and environments.
 
+Before running the examples on your workstation, make sure you are using an
+up-to-date version of CrateDB::
+
+    docker pull crate/crate:nightly
+
 Examples::
 
     ngr test by-language/csharp-npgsql

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pueblo[ngr]==0.0.1
+pueblo[ngr]==0.0.2
 
 # Development.
 # pueblo[ngr] @ git+https://github.com/pyveci/pueblo.git@develop


### PR DESCRIPTION
## About

~~Verifies that the recent updates to the `ngr` test runner do not break anything, when updating to version 0.0.2.~~ Update to ngr 0.0.2.

- https://github.com/pyveci/pueblo/pull/7
