### PR TITLE
CI: Use Python 3.11 for AutoML material

### DIFF
--- a/.github/workflows/test-mlflow.yml
+++ b/.github/workflows/test-mlflow.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:


### PR DESCRIPTION
What the title says.