### PR TITLE
CI: Add Npgsql 8.0.1 to test matrix

### DIFF
--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         dotnet-version: [ '6.0.x', '7.0.x', '8.0.x' ]
-        npgsql-version: [ '6.0.10', '7.0.6' ]
+        npgsql-version: [ '6.0.10', '7.0.6', '8.0.1' ]
         cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers

--- a/by-language/csharp-npgsql/demo.csproj
+++ b/by-language/csharp-npgsql/demo.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="7.0.6" />
+    <PackageReference Include="Npgsql" Version="8.0.1" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.5" />


### PR DESCRIPTION
## About

Npgsql 8.0.0 was released in November 2023. Npgsql 8.0.1 was released in December 2023.

## References
- https://www.npgsql.org/doc/release-notes/8.0.html
- https://github.com/npgsql/npgsql/issues/5503
- https://github.com/crate/crate/issues/15281
- https://github.com/crate/crate-qa/pull/289
- https://github.com/crate/cratedb-examples/pull/169
- [CrateDB 5.5 not working out of the box with Npgsql 8: A PostgreSQL type with the name 'unknown' was not found in the current database info](https://community.cratedb.com/t/cratedb-5-5-not-working-out-of-the-box-with-npgsql-8-a-postgresql-type-with-the-name-unknown-was-not-found-in-the-current-database-info/1689)
- https://github.com/crate/crate/pull/15291
- https://github.com/crate/cratedb-examples/pull/165
- https://github.com/crate/cratedb-examples/pull/195
