### PR TITLE
Npgsql: Fix test matrix, and add .NET 8.0

### DIFF
--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        dotnet-version: [ '5.0.x', '6.0.x', '7.0.x' ]
+        dotnet-version: [ '5.0.x', '6.0.x', '7.0.x', '8.0.x' ]
         npgsql-version: [ '6.0.10', '7.0.6' ]
         cratedb-version: [ 'nightly' ]
 

--- a/.github/workflows/test-npgsql.yml
+++ b/.github/workflows/test-npgsql.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Validate by-language/csharp-npgsql, Npgsql ${{ matrix.npgsql-version }}
         run: |
-          ngr test by-language/csharp-npgsql --npgsql-version=${{ matrix.npgsql-version }}
+          ngr test by-language/csharp-npgsql --dotnet-version=${{ matrix.dotnet-version }} --npgsql-version=${{ matrix.npgsql-version }}
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pueblo[ngr]==0.0.3
+# pueblo[ngr]==0.0.3
 
 # Development.
-# pueblo[ngr] @ git+https://github.com/pyveci/pueblo.git@develop
+pueblo[ngr] @ git+https://github.com/pyveci/pueblo.git@main


### PR DESCRIPTION
## About

The testmatrix for the Npgsql example had a flaw. The .NET framework version was not selected appropriately.

- GH-172

## References

- GH-165
- GH-169
