### PR TITLE
Fix running/testing Gradle projects on contemporary versions of Java

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pueblo[ngr]==0.0.3
+# pueblo[ngr]>=0.0.3
 
 # Development.
-# pueblo[ngr] @ git+https://github.com/pyveci/pueblo.git@develop
+pueblo[ngr] @ git+https://github.com/pyveci/pueblo.git@fix-gradle-wrapper


### PR DESCRIPTION
## About

There is still a need for adjusting how Gradle projects will optimally be invoked. After adjusting the Gradle project incantation procedure recently, `cratedb-examples` was observing a regression on its Gradle project(s).

- https://github.com/pyveci/pueblo/issues/37

The new heuristics in `ngr` will wipe an existing Gradle wrapper and generate a new one, when the `gradle` program is installed on the machine. This accomodates running on contemporary versions of Java, which will otherwise fail like `Unsupported class file major version 65`.

- https://github.com/pyveci/pueblo/pull/38

## References
- This currently blocks/obstructs GH-178.
