### PR TITLE
LLM: Fix LangChain warning about pandas 3.0 and PyArrow

### DIFF
--- a/topic/machine-learning/llm-langchain/pyproject.toml
+++ b/topic/machine-learning/llm-langchain/pyproject.toml
@@ -33,6 +33,7 @@ nb_diff_ignore = [
     "/cells/*/outputs/*/execution_count",
 
     # cratedb-vectorstore-rag-openai-sql.ipynb
+    "/cells/4/outputs",
     "/cells/13/outputs",
     "/cells/15/outputs",
     "/cells/17/outputs",


### PR DESCRIPTION
> Pyarrow will become a required dependency of pandas in the next major release of pandas 
> (pandas 3.0), (to allow more performant data types, such as the Arrow string type, and 
> better interoperability with other libraries) but was not found to be installed on your
> system. If this would cause problems for you, please provide us feedback at
> https://github.com/pandas-dev/pandas/issues/54466.
