### PR TITLE
Python: Fix deprecation of `pandas._testing.makeTimeDataFrame`

### DIFF
--- a/.github/workflows/test-python-sqlalchemy.yml
+++ b/.github/workflows/test-python-sqlalchemy.yml
@@ -38,11 +38,11 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         python-version: [ '3.11', '3.12' ]
-        cratedb-version: [ 'nightly' ]
+        cratedb-version: [ '5.5.3' ]
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/by-language/python-sqlalchemy/insert_dask.py
+++ b/by-language/python-sqlalchemy/insert_dask.py
@@ -15,8 +15,8 @@ Usage
 """
 import dask.dataframe as dd
 from dask.diagnostics import ProgressBar
-from pandas._testing import makeTimeDataFrame
 from crate.client.sqlalchemy.support import insert_bulk
+from pueblo.testing.pandas import makeTimeDataFrame
 
 
 DBURI = "crate://localhost:4200"

--- a/by-language/python-sqlalchemy/insert_pandas.py
+++ b/by-language/python-sqlalchemy/insert_pandas.py
@@ -50,9 +50,9 @@ import click
 import colorlog
 import sqlalchemy as sa
 from colorlog.escape_codes import escape_codes
-from pandas._testing import makeTimeDataFrame
-
 from crate.client.sqlalchemy.support import insert_bulk
+from pueblo.testing.pandas import makeTimeDataFrame
+
 
 logger = logging.getLogger(__name__)
 

--- a/by-language/python-sqlalchemy/requirements-dev.txt
+++ b/by-language/python-sqlalchemy/requirements-dev.txt
@@ -1,2 +1,3 @@
 pytest<8
 pytest-cov<5
+pueblo @ git+https://github.com/pyveci/pueblo.git@pandas-testing


### PR DESCRIPTION
## About

`pandas._testing.makeTimeDataFrame` got removed starting wih pandas 2.2.0.

## References
- https://github.com/pyveci/pueblo/pull/59
- https://github.com/crate/cratedb-examples/pull/236
