### PR TITLE
Python/LLM: Use CrateDB nightly again, resolving woes with JDK 21.0.2

### DIFF
--- a/.github/workflows/test-langchain.yml
+++ b/.github/workflows/test-langchain.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         python-version: [ '3.11' ]
-        cratedb-version: [ '5.5.3' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:

--- a/.github/workflows/test-python-sqlalchemy.yml
+++ b/.github/workflows/test-python-sqlalchemy.yml
@@ -38,7 +38,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         python-version: [ '3.11', '3.12' ]
-        cratedb-version: [ '5.5.3' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:


### PR DESCRIPTION
## About

1fe608d36 and fc26c7a399 temporarily downgraded to CrateDB 5.5.3. This patch reverts those changes, now that nightly builds work well again.

## References
Thank you very much for the quick fix.
- https://github.com/crate/crate/pull/15408
