### PR TITLE
LLM: Turn off validating notebook cell outputs

### DIFF
--- a/topic/machine-learning/llm-langchain/pyproject.toml
+++ b/topic/machine-learning/llm-langchain/pyproject.toml
@@ -32,11 +32,9 @@ nb_diff_ignore = [
     "/cells/*/execution_count",
     "/cells/*/outputs/*/execution_count",
 
-    # cratedb-vectorstore-rag-openai-sql.ipynb
-    "/cells/4/outputs",
-    "/cells/13/outputs",
-    "/cells/15/outputs",
-    "/cells/17/outputs",
+    # Do not compare details of cell outputs.
+    # It is impossible to maintain efficiently.
+    "/cells/*/outputs",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## About

Maintaining a list of individual Jupyter Notebook cells to suppress output comparison is just not sustainable. Let's turn that off.
