### PR TITLE
ML: Update to mlflow-cratedb@main, and cratedb-toolkit 0.0.3

### DIFF
--- a/topic/machine-learning/automl/requirements-dev.txt
+++ b/topic/machine-learning/automl/requirements-dev.txt
@@ -1,9 +1,9 @@
 # Real.
-# cratedb-toolkit
+cratedb-toolkit[io]
 pueblo[notebook,testing]==0.0.6
 
 # Development.
-cratedb-toolkit[io] @ git+https://github.com/crate-workbench/cratedb-toolkit.git@7f3a493
+# cratedb-toolkit[io] @ git+https://github.com/crate-workbench/cratedb-toolkit.git@7f3a493
 # pueblo[notebook,testing] @ git+https://github.com/pyveci/pueblo.git@main
 
 # Workstation.

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -9,4 +9,4 @@ tqdm<5
 werkzeug==2.2.3
 
 # Development.
-mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@toolkit-head
+mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/llm-langchain/requirements-dev.txt
+++ b/topic/machine-learning/llm-langchain/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Real.
-cratedb-toolkit[io]==0.0.3
+cratedb-toolkit[io]
 pueblo[notebook,testing]>=0.0.6
 
 # Development.

--- a/topic/machine-learning/mlops-mlflow/requirements-dev.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements-dev.txt
@@ -1,9 +1,9 @@
 # Real.
-# cratedb-toolkit[io]
+cratedb-toolkit[io]
 pueblo[notebook,testing]==0.0.6
 
 # Development.
-cratedb-toolkit[io] @ git+https://github.com/crate-workbench/cratedb-toolkit.git@7f3a493
+# cratedb-toolkit[io] @ git+https://github.com/crate-workbench/cratedb-toolkit.git@7f3a493
 # pueblo[notebook,testing] @ git+https://github.com/pyveci/pueblo.git@main
 
 # Workstation.

--- a/topic/machine-learning/mlops-mlflow/requirements.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements.txt
@@ -4,4 +4,4 @@ pydantic<3
 salesforce-merlion>=2,<3
 
 # Development.
-mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@toolkit-head
+mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main


### PR DESCRIPTION
## About

Dependency update for notebook educational & QA folders about ML concerns. [cratedb-toolkit 0.0.3](https://github.com/crate-workbench/cratedb-toolkit/releases/tag/v0.0.3) has been released last week.
