### PR TITLE
CI: Refactor GHA workflow recipes. Naming things.

### DIFF
--- a/.github/workflows/dataframe-dask.yml
+++ b/.github/workflows/dataframe-dask.yml
@@ -1,17 +1,17 @@
-name: LangChain
+name: Dask
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-langchain.yml'
-    - 'topic/machine-learning/llm-langchain/**'
+    - '.github/workflows/dataframe-dask.yml'
+    - 'by-dataframe/dask/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-langchain.yml'
-    - 'topic/machine-learning/llm-langchain/**'
+    - '.github/workflows/dataframe-dask.yml'
+    - 'by-dataframe/dask/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11' ]
+        python-version: [ '3.11', '3.12' ]
         cratedb-version: [ 'nightly' ]
 
     services:
@@ -46,9 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
-
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 
@@ -63,13 +62,13 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
-            topic/machine-learning/llm-langchain/requirements.txt
-            topic/machine-learning/llm-langchain/requirements-dev.txt
+            by-dataframe/dask/requirements.txt
+            by-dataframe/dask/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Validate topic/machine-learning/llm-langchain
+      - name: Validate by-dataframe/dask
         run: |
-          ngr test --accept-no-venv topic/machine-learning/llm-langchain
+          ngr test --accept-no-venv by-dataframe/dask

--- a/.github/workflows/dataframe-pandas.yml
+++ b/.github/workflows/dataframe-pandas.yml
@@ -1,17 +1,17 @@
-name: C# Npgsql
+name: pandas
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/*npgsql*'
-    - 'by-language/csharp-npgsql/**'
+    - '.github/workflows/dataframe-pandas.yml'
+    - 'by-dataframe/pandas/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/*npgsql*'
-    - 'by-language/csharp-npgsql/**'
+    - '.github/workflows/dataframe-pandas.yml'
+    - 'by-dataframe/pandas/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -26,15 +26,10 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   test:
     name: "
-     .NET: ${{ matrix.dotnet-version }}
-     Npgsql: ${{ matrix.npgsql-version }}
+     Python: ${{ matrix.python-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -42,48 +37,38 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        dotnet-version: [ '6.0.x', '7.0.x', '8.0.x' ]
-        npgsql-version: [ '6.0.10', '7.0.6', '8.0.1' ]
+        python-version: [ '3.11', '3.12' ]
         cratedb-version: [ 'nightly' ]
 
-    # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
       cratedb:
         image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - name: Set up .NET ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: ${{ matrix.dotnet-version }}
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           architecture: x64
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
+            by-dataframe/pandas/requirements.txt
+            by-dataframe/pandas/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Validate by-language/csharp-npgsql, Npgsql ${{ matrix.npgsql-version }}
+      - name: Validate by-dataframe/pandas
         run: |
-          ngr test by-language/csharp-npgsql --dotnet-version=${{ matrix.dotnet-version }} --npgsql-version=${{ matrix.npgsql-version }}
-
-      # https://github.com/codecov/codecov-action
-      - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          flags: by-language-csharp-npgsql
-          fail_ci_if_error: false
+          ngr test --accept-no-venv by-dataframe/pandas

--- a/.github/workflows/framework-apache-superset.yml
+++ b/.github/workflows/framework-apache-superset.yml
@@ -1,17 +1,17 @@
-name: pandas
+name: Apache Superset
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/df-pandas.yml'
-    - 'by-dataframe/pandas/**'
+    - '.github/workflows/framework-apache-superset.yml'
+    - 'framework/apache-superset/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/df-pandas.yml'
-    - 'by-dataframe/pandas/**'
+    - '.github/workflows/framework-apache-superset.yml'
+    - 'framework/apache-superset/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -27,48 +27,49 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  test:
-    name: "
-     Python: ${{ matrix.python-version }}
-     CrateDB: ${{ matrix.cratedb-version }}
-     on ${{ matrix.os }}"
+
+  tests:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11', '3.12' ]
-        cratedb-version: [ 'nightly' ]
+        os: [ ubuntu-22.04 ]
+        superset-version: [ "2.*", "3.*" ]
+        python-version: [ "3.11" ]
 
     services:
       cratedb:
-        image: crate/crate:${{ matrix.cratedb-version }}
+        image: crate/crate:nightly
         ports:
           - 4200:4200
           - 5432:5432
-        env:
-          CRATE_HEAP_SIZE: 4g
 
+    name: Superset ${{ matrix.superset-version }}, Python ${{ matrix.python-version }}
     steps:
 
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - name: Set up Python
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-          cache: 'pip'
+          cache: "pip"
           cache-dependency-path: |
+            pyproject.toml
             requirements.txt
-            by-dataframe/pandas/requirements.txt
-            by-dataframe/pandas/requirements-dev.txt
+            requirements-test.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Validate by-dataframe/pandas
+      - name: Install Apache Superset ${{ matrix.superset-version }}
         run: |
-          ngr test --accept-no-venv by-dataframe/pandas
+          pip install 'apache-superset==${{ matrix.superset-version }}'
+
+      - name: Validate framework/apache-superset
+        run: |
+          ngr test --accept-no-venv framework/apache-superset

--- a/.github/workflows/lang-java-jooq.yml
+++ b/.github/workflows/lang-java-jooq.yml
@@ -1,17 +1,17 @@
-name: Apache Superset
+name: Java jOOQ
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/apache-superset.yml'
-    - 'framework/apache-superset/**'
+    - '.github/workflows/lang-java-jooq.yml'
+    - 'by-language/java-jooq/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/apache-superset.yml'
-    - 'framework/apache-superset/**'
+    - '.github/workflows/lang-java-jooq.yml'
+    - 'by-language/java-jooq/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -27,16 +27,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-
-  tests:
+  test:
+    name: "
+     Java: ${{ matrix.java-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
+     on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04 ]
-        superset-version: [ "2.*", "3.*" ]
-        python-version: [ "3.11" ]
+        os: [ 'ubuntu-latest' ]
+        java-version: [ '17', '21' ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:
@@ -45,31 +47,31 @@ jobs:
           - 4200:4200
           - 5432:5432
 
-    name: Superset ${{ matrix.superset-version }}, Python ${{ matrix.python-version }}
     steps:
 
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           architecture: x64
-          cache: "pip"
+          cache: 'pip'
           cache-dependency-path: |
-            pyproject.toml
             requirements.txt
-            requirements-test.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Install Apache Superset ${{ matrix.superset-version }}
-        run: |
-          pip install 'apache-superset==${{ matrix.superset-version }}'
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ matrix.java-version }}
+          cache: "gradle"
 
-      - name: Validate framework/apache-superset
+      - name: Validate by-language/java-jooq
         run: |
-          ngr test --accept-no-venv framework/apache-superset
+          ngr test by-language/java-jooq

--- a/.github/workflows/lang-java-maven.yml
+++ b/.github/workflows/lang-java-maven.yml
@@ -4,14 +4,14 @@ on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-java-maven.yml'
+    - '.github/workflows/lang-java-maven.yml'
     - 'by-language/java-jdbc/**'
     - 'by-language/java-qa/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-java-maven.yml'
+    - '.github/workflows/lang-java-maven.yml'
     - 'by-language/java-jdbc/**'
     - 'by-language/java-qa/**'
     - 'requirements.txt'

--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -1,17 +1,17 @@
-name: PHP AMPHP
+name: C# Npgsql
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-php-amphp.yml'
-    - 'by-language/php-amphp/**'
+    - '.github/workflows/lang-npgsql.yml'
+    - 'by-language/csharp-npgsql/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-php-amphp.yml'
-    - 'by-language/php-amphp/**'
+    - '.github/workflows/lang-npgsql.yml'
+    - 'by-language/csharp-npgsql/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -26,10 +26,15 @@ concurrency:
   cancel-in-progress: true
   group: ${{ github.workflow }}-${{ github.ref }}
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   test:
     name: "
-     PHP: ${{ matrix.php-version }}
+     .NET: ${{ matrix.dotnet-version }}
+     Npgsql: ${{ matrix.npgsql-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -37,12 +42,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php-version: [ '7.4', '8.2', '8.3' ]
+        dotnet-version: [ '6.0.x', '7.0.x', '8.0.x' ]
+        npgsql-version: [ '6.0.10', '7.0.6', '8.0.1' ]
         cratedb-version: [ 'nightly' ]
 
+    # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432
@@ -51,6 +58,11 @@ jobs:
 
       - name: Acquire sources
         uses: actions/checkout@v4
+
+      - name: Set up .NET ${{ matrix.dotnet-version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.dotnet-version }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -65,13 +77,13 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      # https://github.com/marketplace/actions/setup-php-action
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          tools: composer
-
-      - name: Validate by-language/php-amphp
+      - name: Validate by-language/csharp-npgsql, Npgsql ${{ matrix.npgsql-version }}
         run: |
-          ngr test by-language/php-amphp
+          ngr test by-language/csharp-npgsql --dotnet-version=${{ matrix.dotnet-version }} --npgsql-version=${{ matrix.npgsql-version }}
+
+      # https://github.com/codecov/codecov-action
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          flags: by-language-csharp-npgsql
+          fail_ci_if_error: false

--- a/.github/workflows/lang-php-amphp.yml
+++ b/.github/workflows/lang-php-amphp.yml
@@ -1,17 +1,17 @@
-name: SQLAlchemy
+name: PHP AMPHP
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/sqlalchemy.yml'
-    - 'by-language/python-sqlalchemy/**'
+    - '.github/workflows/lang-php-amphp.yml'
+    - 'by-language/php-amphp/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/sqlalchemy.yml'
-    - 'by-language/python-sqlalchemy/**'
+    - '.github/workflows/lang-php-amphp.yml'
+    - 'by-language/php-amphp/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test:
     name: "
-     Python: ${{ matrix.python-version }}
+     PHP: ${{ matrix.php-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -37,17 +37,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11', '3.12' ]
+        php-version: [ '7.4', '8.2', '8.3' ]
         cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:
-        image: crate/crate:${{ matrix.cratedb-version }}
+        image: crate/crate:nightly
         ports:
           - 4200:4200
           - 5432:5432
-        env:
-          CRATE_HEAP_SIZE: 4g
 
     steps:
 
@@ -57,18 +55,23 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           architecture: x64
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
-            by-language/python-sqlalchemy/requirements.txt
-            by-language/python-sqlalchemy/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Validate by-language/python-sqlalchemy
+      # https://github.com/marketplace/actions/setup-php-action
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer
+
+      - name: Validate by-language/php-amphp
         run: |
-          ngr test --accept-no-venv by-language/python-sqlalchemy
+          ngr test by-language/php-amphp

--- a/.github/workflows/lang-php-pdo.yml
+++ b/.github/workflows/lang-php-pdo.yml
@@ -1,17 +1,17 @@
-name: Testcontainers for Java
+name: PHP PDO
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/testcontainers-java.yml'
-    - 'testing/testcontainers/java/**'
+    - '.github/workflows/lang-php-pdo.yml'
+    - 'by-language/php-pdo/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/testcontainers-java.yml'
-    - 'testing/testcontainers/java/**'
+    - '.github/workflows/lang-php-pdo.yml'
+    - 'by-language/php-pdo/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test:
     name: "
-     Java: ${{ matrix.java-version }}
+     PHP: ${{ matrix.php-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -37,8 +37,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        java-version: [ '11', '17', '21' ]
+        php-version: [ '7.4', '8.2', '8.3' ]
         cratedb-version: [ 'nightly' ]
+
+    services:
+      cratedb:
+        image: crate/crate:nightly
+        ports:
+          - 4200:4200
+          - 5432:5432
 
     steps:
 
@@ -58,13 +65,13 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      - name: Set up Java
-        uses: actions/setup-java@v4
+      # https://github.com/marketplace/actions/setup-php-action
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
         with:
-          distribution: "temurin"
-          java-version: ${{ matrix.java-version }}
-          cache: "gradle"
+          php-version: ${{ matrix.php-version }}
+          extensions: pdo_pgsql
 
-      - name: Validate testing/testcontainers/java
+      - name: Validate by-language/php-pdo
         run: |
-          ngr test testing/testcontainers/java
+          ngr test by-language/php-pdo

--- a/.github/workflows/lang-python-sqlalchemy.yml
+++ b/.github/workflows/lang-python-sqlalchemy.yml
@@ -1,17 +1,17 @@
-name: Dask
+name: SQLAlchemy
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/df-dask.yml'
-    - 'by-dataframe/dask/**'
+    - '.github/workflows/lang-python-sqlalchemy.yml'
+    - 'by-language/python-sqlalchemy/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/df-dask.yml'
-    - 'by-dataframe/dask/**'
+    - '.github/workflows/lang-python-sqlalchemy.yml'
+    - 'by-language/python-sqlalchemy/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -62,13 +62,13 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
-            by-dataframe/dask/requirements.txt
-            by-dataframe/dask/requirements-dev.txt
+            by-language/python-sqlalchemy/requirements.txt
+            by-language/python-sqlalchemy/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Validate by-dataframe/dask
+      - name: Validate by-language/python-sqlalchemy
         run: |
-          ngr test --accept-no-venv by-dataframe/dask
+          ngr test --accept-no-venv by-language/python-sqlalchemy

--- a/.github/workflows/lang-ruby.yml
+++ b/.github/workflows/lang-ruby.yml
@@ -1,17 +1,17 @@
-name: PHP PDO
+name: Ruby
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-php-pdo.yml'
-    - 'by-language/php-pdo/**'
+    - '.github/workflows/lang-ruby.yml'
+    - 'by-language/ruby/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-php-pdo.yml'
-    - 'by-language/php-pdo/**'
+    - '.github/workflows/lang-ruby.yml'
+    - 'by-language/ruby/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test:
     name: "
-     PHP: ${{ matrix.php-version }}
+     Ruby: ${{ matrix.ruby-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php-version: [ '7.4', '8.2', '8.3' ]
+        ruby-version: [ '2.7', '3.0', '3.1', '3.2', 'truffleruby', 'truffleruby+graalvm' ]
         cratedb-version: [ 'nightly' ]
 
     services:
@@ -65,13 +65,16 @@ jobs:
         run: |
           pip install -r requirements.txt
 
-      # https://github.com/marketplace/actions/setup-php-action
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          php-version: ${{ matrix.php-version }}
-          extensions: pdo_pgsql
+          ruby-version: "${{ matrix.ruby-version }}"
+          bundler-cache: true
 
-      - name: Validate by-language/php-pdo
+      - name: Install "libpq-dev"
+        if: ${{ matrix.ruby-version == 'jruby' }}
+        run: sudo apt-get update && sudo apt-get install --yes build-essential libpq-dev
+
+      - name: Validate by-language/ruby
         run: |
-          ngr test by-language/php-pdo
+          ngr test by-language/ruby

--- a/.github/workflows/ml-automl.yml
+++ b/.github/workflows/ml-automl.yml
@@ -1,17 +1,17 @@
-name: Ruby
+name: AutoML
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-ruby.yml'
-    - 'by-language/ruby/**'
+    - '.github/workflows/ml-automl.yml'
+    - 'topic/machine-learning/automl/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-ruby.yml'
-    - 'by-language/ruby/**'
+    - '.github/workflows/ml-automl.yml'
+    - 'topic/machine-learning/automl/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test:
     name: "
-     Ruby: ${{ matrix.ruby-version }}
+     Python: ${{ matrix.python-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        ruby-version: [ '2.7', '3.0', '3.1', '3.2', 'truffleruby', 'truffleruby+graalvm' ]
+        python-version: [ '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:
@@ -47,6 +47,9 @@ jobs:
           - 4200:4200
           - 5432:5432
 
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
     steps:
 
       - name: Acquire sources
@@ -55,26 +58,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           architecture: x64
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
+            topic/machine-learning/automl/requirements.txt
+            topic/machine-learning/automl/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "${{ matrix.ruby-version }}"
-          bundler-cache: true
-
-      - name: Install "libpq-dev"
-        if: ${{ matrix.ruby-version == 'jruby' }}
-        run: sudo apt-get update && sudo apt-get install --yes build-essential libpq-dev
-
-      - name: Validate by-language/ruby
+      - name: Validate topic/machine-learning/automl
         run: |
-          ngr test by-language/ruby
+          ngr test --accept-no-venv topic/machine-learning/automl

--- a/.github/workflows/ml-langchain.yml
+++ b/.github/workflows/ml-langchain.yml
@@ -1,17 +1,17 @@
-name: MLflow
+name: LangChain
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-mlflow.yml'
-    - 'topic/machine-learning/mlops-mlflow/**'
+    - '.github/workflows/ml-langchain.yml'
+    - 'topic/machine-learning/llm-langchain/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-mlflow.yml'
-    - 'topic/machine-learning/mlops-mlflow/**'
+    - '.github/workflows/ml-langchain.yml'
+    - 'topic/machine-learning/llm-langchain/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -42,10 +42,13 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432
+
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
 
@@ -60,13 +63,13 @@ jobs:
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
-            topic/machine-learning/mlops-mlflow/requirements.txt
-            topic/machine-learning/mlops-mlflow/requirements-dev.txt
+            topic/machine-learning/llm-langchain/requirements.txt
+            topic/machine-learning/llm-langchain/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Validate topic/machine-learning/mlops-mlflow
+      - name: Validate topic/machine-learning/llm-langchain
         run: |
-          ngr test --accept-no-venv topic/machine-learning/mlops-mlflow
+          ngr test --accept-no-venv topic/machine-learning/llm-langchain

--- a/.github/workflows/ml-mlflow.yml
+++ b/.github/workflows/ml-mlflow.yml
@@ -1,17 +1,17 @@
-name: Java jOOQ
+name: MLflow
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-java-jooq.yml'
-    - 'by-language/java-jooq/**'
+    - '.github/workflows/ml-mlflow.yml'
+    - 'topic/machine-learning/mlops-mlflow/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-java-jooq.yml'
-    - 'by-language/java-jooq/**'
+    - '.github/workflows/ml-mlflow.yml'
+    - 'topic/machine-learning/mlops-mlflow/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test:
     name: "
-     Java: ${{ matrix.java-version }}
+     Python: ${{ matrix.python-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        java-version: [ '17', '21' ]
+        python-version: [ '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:
@@ -55,23 +55,18 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: ${{ matrix.python-version }}
           architecture: x64
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
+            topic/machine-learning/mlops-mlflow/requirements.txt
+            topic/machine-learning/mlops-mlflow/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: ${{ matrix.java-version }}
-          cache: "gradle"
-
-      - name: Validate by-language/java-jooq
+      - name: Validate topic/machine-learning/mlops-mlflow
         run: |
-          ngr test by-language/java-jooq
+          ngr test --accept-no-venv topic/machine-learning/mlops-mlflow

--- a/.github/workflows/stack-kafka-flink.yml
+++ b/.github/workflows/stack-kafka-flink.yml
@@ -4,13 +4,13 @@ on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-kafka-flink.yml'
+    - '.github/workflows/stack-kafka-flink.yml'
     - 'stacks/kafka-flink/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-kafka-flink.yml'
+    - '.github/workflows/stack-kafka-flink.yml'
     - 'stacks/kafka-flink/**'
     - 'requirements.txt'
 

--- a/.github/workflows/testing-testcontainers-java.yml
+++ b/.github/workflows/testing-testcontainers-java.yml
@@ -1,17 +1,17 @@
-name: AutoML
+name: Testcontainers for Java
 
 on:
   pull_request:
     branches: ~
     paths:
-    - '.github/workflows/test-automl.yml'
-    - 'topic/machine-learning/automl/**'
+    - '.github/workflows/testing-testcontainers-java.yml'
+    - 'testing/testcontainers/java/**'
     - 'requirements.txt'
   push:
     branches: [ main ]
     paths:
-    - '.github/workflows/test-automl.yml'
-    - 'topic/machine-learning/automl/**'
+    - '.github/workflows/testing-testcontainers-java.yml'
+    - 'testing/testcontainers/java/**'
     - 'requirements.txt'
 
   # Allow job to be triggered manually.
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   test:
     name: "
-     Python: ${{ matrix.python-version }}
+     Java: ${{ matrix.java-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -37,18 +37,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11' ]
+        java-version: [ '11', '17', '21' ]
         cratedb-version: [ 'nightly' ]
-
-    services:
-      cratedb:
-        image: crate/crate:nightly
-        ports:
-          - 4200:4200
-          - 5432:5432
-
-    env:
-      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 
     steps:
 
@@ -58,18 +48,23 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
           architecture: x64
           cache: 'pip'
           cache-dependency-path: |
             requirements.txt
-            topic/machine-learning/automl/requirements.txt
-            topic/machine-learning/automl/requirements-dev.txt
 
       - name: Install utilities
         run: |
           pip install -r requirements.txt
 
-      - name: Validate topic/machine-learning/automl
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: ${{ matrix.java-version }}
+          cache: "gradle"
+
+      - name: Validate testing/testcontainers/java
         run: |
-          ngr test --accept-no-venv topic/machine-learning/automl
+          ngr test testing/testcontainers/java


### PR DESCRIPTION
## About

With a growing list of integrations to be validated, this patch attempts to improve coherency, better discriminating between different topic domains by prefixing the corresponding GHA workflow recipe files, using:

- `dataframe-`
- `framework-`
- `lang-`
- `ml-`
- `stack-`
- `testing-`

Unfortunately, we can't use subdirectories for that purpose.
- GH-272
- [Feature request: allow workflow configuration in sub-folders #18055](https://github.com/orgs/community/discussions/18055)

## Status

The total count on integration tests is 41. Just one more!

![image](https://github.com/crate/cratedb-examples/assets/453543/60f4f21e-3f4c-499b-b2d8-1495a9dac32e)


/cc @marijaselakovic, @surister, @ckurze 