### PR TITLE
CI: Various improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,13 @@ updates:
     schedule:
       interval: "weekly"
 
+  # Frameworks.
+
+  - directory: "/framework/apache-superset"
+    package-ecosystem: "pip"
+    schedule:
+      interval: "weekly"
+
   # Topics.
 
   - directory: "/topic/machine-learning/automl"

--- a/.github/workflows/framework-apache-superset.yml
+++ b/.github/workflows/framework-apache-superset.yml
@@ -44,6 +44,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     name: Superset ${{ matrix.superset-version }}, Python ${{ matrix.python-version }}
     steps:

--- a/.github/workflows/framework-apache-superset.yml
+++ b/.github/workflows/framework-apache-superset.yml
@@ -28,7 +28,12 @@ concurrency:
 
 jobs:
 
-  tests:
+  test:
+    name: "
+     Superset: ${{ matrix.superset-version }}
+     Python: ${{ matrix.python-version }}
+     CrateDB: ${{ matrix.cratedb-version }}
+     on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -37,17 +42,17 @@ jobs:
         os: [ ubuntu-22.04 ]
         superset-version: [ "2.*", "3.*" ]
         python-version: [ "3.11" ]
+        cratedb-version: [ 'nightly' ]
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432
         env:
           CRATE_HEAP_SIZE: 4g
 
-    name: Superset ${{ matrix.superset-version }}, Python ${{ matrix.python-version }}
     steps:
 
       - name: Acquire sources

--- a/.github/workflows/lang-java-jooq.yml
+++ b/.github/workflows/lang-java-jooq.yml
@@ -46,6 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 

--- a/.github/workflows/lang-java-jooq.yml
+++ b/.github/workflows/lang-java-jooq.yml
@@ -42,7 +42,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/lang-java-maven.yml
+++ b/.github/workflows/lang-java-maven.yml
@@ -44,7 +44,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/lang-java-maven.yml
+++ b/.github/workflows/lang-java-maven.yml
@@ -48,6 +48,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 

--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -53,6 +53,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 

--- a/.github/workflows/lang-php-amphp.yml
+++ b/.github/workflows/lang-php-amphp.yml
@@ -46,6 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 

--- a/.github/workflows/lang-php-amphp.yml
+++ b/.github/workflows/lang-php-amphp.yml
@@ -42,7 +42,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/lang-php-pdo.yml
+++ b/.github/workflows/lang-php-pdo.yml
@@ -46,6 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 

--- a/.github/workflows/lang-php-pdo.yml
+++ b/.github/workflows/lang-php-pdo.yml
@@ -42,7 +42,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/lang-ruby.yml
+++ b/.github/workflows/lang-ruby.yml
@@ -46,6 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 

--- a/.github/workflows/lang-ruby.yml
+++ b/.github/workflows/lang-ruby.yml
@@ -42,7 +42,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/ml-automl.yml
+++ b/.github/workflows/ml-automl.yml
@@ -46,6 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ml-automl.yml
+++ b/.github/workflows/ml-automl.yml
@@ -19,7 +19,7 @@ on:
 
   # Run job each night after CrateDB nightly has been published.
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 6 * * *'
 
 # Cancel in-progress jobs when pushing to the same branch.
 concurrency:

--- a/.github/workflows/ml-automl.yml
+++ b/.github/workflows/ml-automl.yml
@@ -42,7 +42,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/ml-langchain.yml
+++ b/.github/workflows/ml-langchain.yml
@@ -46,6 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/ml-mlflow.yml
+++ b/.github/workflows/ml-mlflow.yml
@@ -46,6 +46,8 @@ jobs:
         ports:
           - 4200:4200
           - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
 
     steps:
 

--- a/.github/workflows/ml-mlflow.yml
+++ b/.github/workflows/ml-mlflow.yml
@@ -42,7 +42,7 @@ jobs:
 
     services:
       cratedb:
-        image: crate/crate:nightly
+        image: crate/crate:${{ matrix.cratedb-version }}
         ports:
           - 4200:4200
           - 5432:5432

--- a/.github/workflows/stack-kafka-flink.yml
+++ b/.github/workflows/stack-kafka-flink.yml
@@ -28,7 +28,7 @@ concurrency:
 
 jobs:
 
-  tests:
+  test:
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
## About

Following up on GH-273, this patch further improves the CI configuration.

- Reschedule ml-automl job to run at 6 o'clock, three hours later
- Reconfigure CrateDB container to use `CRATE_HEAP_SIZE: 4g`
- Align GHA recipes about CrateDB container configuration
- Add Apache Superset to Dependabot configuration
- Let Dependabot drive version compliance checks for Apache Superset
