### PR TITLE
Documentation: Add a bit of style to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,182 @@
+<div align="center">
+
 # CrateDB Examples
 
-## About
+✨ _A collection of clear and concise examples how to work with [CrateDB]._ ✨
 
-This repository contains a collection of clear and concise examples
-how to work with [CrateDB](https://github.com/crate/crate). You can
-use them for educational purposes, or as blueprints for your own
-projects.
+🔗 Quick links:
+[Application](./application) •
+[Dataframe](./by-dataframe) •
+[Language](./by-language) •
+[Testing](./testing) •
+[Topic](./topic)
 
-## Layout
+📖 More information:
+[Drivers and Integrations](https://cratedb.com/docs/clients/) •
+[Integration Tutorials](https://community.cratedb.com/t/overview-of-cratedb-integration-tutorials/1015) •
+[Reference Documentation](https://cratedb.com/docs/crate/reference/)
 
--   The `by-dataframe` folder contains example code snippets how
+</div>
+
+
+## 👨‍💻 Usage
+
+- You can explore the content by browsing folders within the repository.
+  Main sections can be explored by using the quick links in the header
+  area.
+
+- If you are looking for something specific, please use GitHub search, for
+  example, [searching for "jdbc"].
+
+- You can use the code snippets for educational and knowledge base purposes,
+  or as blueprints within your own projects.
+
+- The repository is also used to support QA processes. Each example is
+  designed to be invoked as an integration test case, accompanied by a
+  corresponding CI validation job.
+
+
+## 🧐 What's inside
+
+This section gives you an overview about what's inside the relevant
+folders.
+
+-   **by-dataframe** contains example code snippets how
     to work with dataframe libraries like pandas, Polars, Dask,
     Spark, and friends.
 
--   The `by-language` folder contains demo programs / technical
+-   **by-language** contains demo programs / technical
     investigations outlining how to get started quickly with CrateDB
     using different programming languages and frameworks.
 
--   The `framework` folder contains integration scenarios with
-    full-fledged applications or software frameworks.
+-   **application** contains integration scenarios with
+    full-fledged applications and software frameworks.
 
--   The `stacks` folder contains more grown-up, complete usage scenarios
-    where CrateDB is part of a larger software stack. Those resources
-    may also be used within \"reference architecture\" types of
-    documentation.
-
--   The `testing` folder contains reference implementations about how to
+-   **testing** contains reference implementations about how to
     use different kinds of test layers for testing your applications
     with CrateDB.
 
-## Testing
+-   **topic** mostly contains Jupyter Notebooks outlining different
+    use cases around working with time-series data, and demonstrating
+    machine learning technologies together with CrateDB.
 
-The repository uses an universal test runner to invoke test suites of
-different languages and environments.
 
-Before running the examples on your workstation, make sure you are using
-an up-to-date version of CrateDB:
+## ✅ CI Status
 
-    docker pull crate/crate:nightly
+This section outlines the status of integration tests on CI/GHA.
 
-### Introducing `ngr`
+<table>
+<thead>
+<tr>
+<th></th>
+<th>Status</th>
+</tr>
+</thead>
+
+<tbody>
+
+<tr>
+<td>
+<b>Application</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/application-apache-kafka-flink.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/application-apache-kafka-flink.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/application-apache-superset.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/application-apache-superset.yml/badge.svg" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Dataframe</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/dataframe-dask.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/dataframe-dask.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/dataframe-pandas.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/dataframe-pandas.yml/badge.svg" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Language</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-npgsql.yml">
+      <img src="https://github.com/crate/cratedb-examples/actions/workflows/lang-npgsql.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-java-jooq.yml">
+      <img src="https://github.com/crate/cratedb-examples/actions/workflows/lang-java-jooq.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-java-maven.yml">
+      <img src="https://github.com/crate/cratedb-examples/actions/workflows/lang-java-maven.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-php-amphp.yml">
+      <img src="https://github.com/crate/cratedb-examples/actions/workflows/lang-php-amphp.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-php-pdo.yml">
+      <img src="https://github.com/crate/cratedb-examples/actions/workflows/lang-php-pdo.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-python-sqlalchemy.yml">
+      <img src="https://github.com/crate/cratedb-examples/actions/workflows/lang-python-sqlalchemy.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/lang-ruby.yml">
+      <img src="https://github.com/crate/cratedb-examples/actions/workflows/lang-ruby.yml/badge.svg" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Testing</b>
+</td>
+<td>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/testing-testcontainers-java.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/testing-testcontainers-java.yml/badge.svg" loading="lazy"></a>
+</td>
+</tr>
+
+<tr>
+<td>
+<b>Topic</b>
+</td>
+<td>
+<b>Machine Learning</b>
+<br>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/ml-automl.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/ml-automl.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/ml-langchain.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/ml-langchain.yml/badge.svg" loading="lazy"></a>
+<a href="https://github.com/crate/cratedb-examples/actions/workflows/ml-mlflow.yml">
+    <img src="https://github.com/crate/cratedb-examples/actions/workflows/ml-mlflow.yml/badge.svg" loading="lazy"></a>
+</td>
+</tr>
+
+</tbody>
+</table>
+
+
+## 🏕️ Testing
+
+In the same way as on CI, you can invoke the example programs easily on your
+workstation, in order to quickly get started on behalf of working example code,
+or to verify connectivity within your computing environment.
+
+### Prerequisites
+
+For invoking the software integration tests, you will need installations of
+Docker, Python, and Git on your workstation.
+
+Before running the tests, make sure to supply an instance of CrateDB. In order
+to use and verify the most recent available code, let's select the OCI image
+`crate/crate:nightly`.
+
+```shell
+docker run --rm -it --pull=always \
+    --name=cratedb --publish=4200:4200 --publish=5432:5432 \
+    --env=CRATE_HEAP_SIZE=4g \
+    crate/crate:nightly -Cdiscovery.type=single-node
+```
+
+### Test Runner `ngr`
+
+The repository uses a universal test runner to invoke test suites of
+different languages and environments, called `ngr`.
 
 In order to run specific sets of test cases, you do not need to leave
 the top-level directory, or run any kind of environment setup procedures.
@@ -50,23 +187,53 @@ If all goes well, just select one of the folders of interest, and invoke
     ngr test by-language/python-sqlalchemy
     ngr test by-language/php-amphp
     ngr test by-dataframe/dask
-    ngr test framework/apache-superset
+    ngr test application/apache-superset
     ngr test testing/testcontainers/java
     ngr test topic/machine-learning/llm-langchain
 
-The authors recommend to invoke `ngr` from within a Python virtualenv,
-in order to isolate its installation from the system Python.
+> [!NOTE]
+> It is recommended to invoke `ngr` from within a Python virtualenv,
+> in order to isolate its installation from the system Python.
+> Installing `ngr` works like this:
+> ```shell
+> git clone https://github.com/crate/cratedb-examples
+> cd cratedb-examples
+> python3 -m venv .venv
+> source .venv/bin/activate
+> pip install -r requirements.txt
+> ```
 
-### Running a Test Matrix
+### Test Matrix Support
 
 Some examples optionally obtain parameters on invocation time.
 
-An example are the test cases for Npgsql, which accept the version number of
+One example is the test suite for Npgsql, which accepts the version number of
 the Npgsql driver release to be obtained from the environment at runtime,
 overriding any internally specified versions. Example:
 
     ngr test by-language/csharp-npgsql --npgsql-version=6.0.9
 
-This feature is handy if you are running a test matrix, which is
-responsible for driving the version numbers, instead of using any
-versions nailed within local specification files of any sort.
+> [!TIP]
+> This feature is handy if you are running a test matrix, which is
+> responsible for driving the version numbers, instead of using the
+> version numbers nailed within local specification files of any sort.
+
+
+## 💁 Contributing
+
+Interested in contributing to this project? Thanks so much for your interest! 
+
+As an open-source project, we are always looking for improvements in form of
+contributions, whether it be in the form of a new feature, improved
+infrastructure, or better documentation.
+
+Your bug reports, feature requests, and patches are greatly appreciated.
+
+
+## 🌟 Contributors
+
+[![Contributors to CrateDB Examples](https://contrib.rocks/image?repo=crate/cratedb-examples)](https://github.com/crate/cratedb-examples/graphs/contributors)
+
+
+[CrateDB]: https://github.com/crate/crate
+[searching for "jdbc"]: https://github.com/search?q=repo%3Acrate%2Fcratedb-examples+jdbc


### PR DESCRIPTION
## About

Text-only is boring, and this repository will probably never have a dedicated representation as a slot within the documentation, so this patch intends to improve the home page (README) a bit, to provide better guidance in conveying what's inside, also visually more pleasant.

## Review

Any kinds of suggestions are welcome. Thank you.

## Preview

See [README](https://github.com/crate/cratedb-examples/blob/amo/readme-styled/README.md).
