### PR TITLE
CI: Use Python 3.12 for exercising native Python test layers

### DIFF
--- a/.github/workflows/testing-native-python.yml
+++ b/.github/workflows/testing-native-python.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'macos-latest' ]
-        python-version: [ '3.7', '3.11' ]
+        python-version: [ '3.7', '3.12' ]
         cratedb-version: [ 'nightly' ]
 
     steps:

--- a/testing/native/python-pytest/requirements.txt
+++ b/testing/native/python-pytest/requirements.txt
@@ -1,3 +1,4 @@
 crash==0.31.2
 pytest<9
 pytest-crate==0.3.0
+setuptools  # Temporary, until next cr8 release.

--- a/testing/native/python-unittest/requirements.txt
+++ b/testing/native/python-unittest/requirements.txt
@@ -1,2 +1,3 @@
 cr8==0.25.0
 crash==0.31.2
+setuptools  # Temporary, until next cr8 release.


### PR DESCRIPTION
## About

The "native" tests do not succeed on Python 3.12 yet, cr8 needs a corresponding fix.

```python
  File "/path/to/cratedb-examples/testing/native/python-unittest/test_unittest.py", line 12, in <module>
    from cr8.run_crate import create_node
  File "/path/to/cratedb-examples/.venv312/lib/python3.12/site-packages/cr8/__init__.py", line 1, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```
