### PR TITLE
ML: Update to mlflow-cratedb 2.10.2

### DIFF
--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -1,6 +1,6 @@
 # Real.
 crate[sqlalchemy]
-# mlflow-cratedb==2.8.1
+mlflow-cratedb==2.10.2
 plotly<5.20
 pycaret[analysis,models,tuner,parallel,test]==3.3.0
 pydantic<2
@@ -9,4 +9,4 @@ tqdm<5
 werkzeug==2.2.3
 
 # Development.
-mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main
+# mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/mlops-mlflow/requirements.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements.txt
@@ -1,7 +1,7 @@
 # Real.
-# mlflow-cratedb==2.8.1
+mlflow-cratedb==2.10.2
 pydantic<3
 salesforce-merlion>=2,<3
 
 # Development.
-mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main
+# mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main


### PR DESCRIPTION
## About
What the title says.

## References
- https://github.com/crate-workbench/mlflow-cratedb/releases/tag/v2.10.2

/cc @andnig, @ckurze 