### PR TITLE
Set crate-python version to fixed to handle langchain requirement

### DIFF
--- a/topic/machine-learning/llm-langchain/cratedb_rag_customer_support.ipynb
+++ b/topic/machine-learning/llm-langchain/cratedb_rag_customer_support.ipynb
@@ -49,7 +49,7 @@
    "source": [
     "#!pip install -r requirements.txt\n",
     "\n",
-    "Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
+    "# Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
     "#!pip install -r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/machine-learning/llm-langchain/requirements.txt\""
    ]
   },

--- a/topic/machine-learning/llm-langchain/cratedb_rag_customer_support_langchain.ipynb
+++ b/topic/machine-learning/llm-langchain/cratedb_rag_customer_support_langchain.ipynb
@@ -85,7 +85,7 @@
    "source": [
     "#!pip install -r requirements.txt\n",
     "\n",
-    "Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
+    "# Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
     "#!pip install -r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/machine-learning/llm-langchain/requirements.txt\""
    ]
   },

--- a/topic/machine-learning/llm-langchain/requirements.txt
+++ b/topic/machine-learning/llm-langchain/requirements.txt
@@ -1,6 +1,6 @@
 # Real.
 crash
-crate[sqlalchemy]>=0.34
+crate[sqlalchemy]==0.34.0
 cratedb-toolkit==0.0.5
 
 # langchain[cratedb,openai]==0.0.354


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This should temporarily fix #302 

```
The conflict is caused by:
    The user requested crate[sqlalchemy]>=0.34
    cratedb-toolkit 0.0.5 depends on crate[sqlalchemy]>=0.34
    langchain[cratedb,openai] 0.1.4 depends on crate[sqlalchemy]<0.35.0 and >=0.34.0; extra == "cratedb"
```

## Checklist

 - [x] Link to issue this PR refers to (if applicable): #302
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
