### PR TITLE
Chore: Make subprocess.check_call not suppress its output

### DIFF
--- a/application/apache-superset/conftest.py
+++ b/application/apache-superset/conftest.py
@@ -27,7 +27,7 @@ def invoke_superset(command: str):
     Invoke `superset` command.
     """
     command = f"{superset_bin} {command}"
-    subprocess.check_call(shlex.split(command), env=superset_env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    subprocess.check_call(shlex.split(command), env=superset_env)
 
 
 # Test suite fixtures.


### PR DESCRIPTION
## Problem

It is hard to debug GH-313 when not being able to observe any stderr output from the child process.
