### PR TITLE
Apache Superset: Remove testing of Apache Superset 2.x

### DIFF
--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
-        superset-version: [ "2.*", "3.*" ]
+        superset-version: [ "3.*" ]
         python-version: [ "3.11" ]
         cratedb-version: [ 'nightly' ]
 

--- a/application/apache-superset/requirements.txt
+++ b/application/apache-superset/requirements.txt
@@ -1,3 +1,2 @@
 apache-superset
 crate[sqlalchemy]==0.35.2
-marshmallow_enum<2  # Seems to be missing from `apache-superset`?


### PR DESCRIPTION
## About
Apache Superset 2.x is no longer actively supported. This patch removes testing on CI.

## References
- GH-313
- https://github.com/apache/superset/discussions/27211
