### PR TITLE
Apache Superset: Use Python 3.12 on CI

### DIFF
--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -47,7 +47,10 @@ jobs:
           # "3.*",
           "4.*",
         ]
-        python-version: [ "3.9", "3.11" ]
+        python-version: [
+          "3.9",
+          "3.12",
+        ]
         cratedb-version: [ 'nightly' ]
 
     services:


### PR DESCRIPTION
## About

Probing Apache Superset with Python 3.12.

-- https://devguide.python.org/versions/
