### PR TITLE
Fix dependency installation for `topic/machine-learning/automl`

### DIFF
--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -5,7 +5,6 @@ plotly<5.20
 pycaret[models,parallel,test]==3.3.0
 pydantic<2
 python-dotenv<2
-tqdm<5
 
 # Development.
 # mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -2,7 +2,7 @@
 crate[sqlalchemy]
 mlflow-cratedb==2.10.2
 plotly<5.20
-pycaret[analysis,models,parallel,test]==3.3.0
+pycaret[models,parallel,test]==3.3.0
 pydantic<2
 python-dotenv<2
 tqdm<5

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -6,7 +6,6 @@ pycaret[analysis,models,tuner,parallel,test]==3.3.0
 pydantic<2
 python-dotenv<2
 tqdm<5
-werkzeug==2.2.3
 
 # Development.
 # mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -2,7 +2,7 @@
 crate[sqlalchemy]
 mlflow-cratedb==2.10.2
 plotly<5.20
-pycaret[analysis,models,tuner,parallel,test]==3.3.0
+pycaret[analysis,models,parallel,test]==3.3.0
 pydantic<2
 python-dotenv<2
 tqdm<5


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Google Colab currently fails running `pip install`. `pycaret[analysis]` pulls in `pyyaml==5.3.1` (from 2020!), which no longer installs on Google Colab:

```
Collecting pyyaml==5.3.1 (from pycaret[analysis,models,parallel,test,tuner]==3.3.0->-r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/machine-learning/automl/requirements.txt (line 5))
  Using cached PyYAML-5.3.1.tar.gz (269 kB)
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  Preparing metadata (setup.py) ... error
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.
```

I couldn't find any explicit documentation from PyCaret on what the `analysis` extra does. On [master](https://github.com/pycaret/pycaret/blob/master/requirements-optional.txt), PyCaret already updated PyYAML to 5.4.1 (from 2021 🙄). Can anyone confirm if the extra is actually used?

There was also the `tuner` extra used which doesn't exist (any more) as well as a few direct dependencies I could not find any usages of.

## Checklist

 - [X] Link to issue this PR refers to (if applicable): 
 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
