### PR TITLE
Apache Kafka+Flink: Update to cratedb-flink-jobs-0.5, using Flink 1.18

### DIFF
--- a/application/apache-kafka-flink/.env
+++ b/application/apache-kafka-flink/.env
@@ -31,6 +31,6 @@ CRATEDB_HTTP_URL="${CRATEDB_HTTP_SCHEME}://${CRATEDB_USERNAME}:${CRATEDB_PASSWOR
 
 # Options for acquiring the Flink job JAR file.
 # https://github.com/crate/cratedb-flink-jobs
-FLINK_JOB_JAR_VERSION=0.4
+FLINK_JOB_JAR_VERSION=0.5
 FLINK_JOB_JAR_FILE=cratedb-flink-jobs-${FLINK_JOB_JAR_VERSION}.jar
 FLINK_JOB_JAR_URL=https://github.com/crate/cratedb-flink-jobs/releases/download/${FLINK_JOB_JAR_VERSION}/${FLINK_JOB_JAR_FILE}


### PR DESCRIPTION
## About

A patch by @matriv is apparently part of Flink 1.18 now.

- https://github.com/apache/flink-connector-jdbc/pull/29

Accompanying the release of [cratedb-flink-jobs-0.5](https://github.com/crate/cratedb-flink-jobs/releases/tag/0.5), which includes the update to Flink 1.18, this patch verifies it on CI.

/cc @surister
