### PR TITLE
ML/LLM/RAG: Skip Vertex AI examples on CI

### DIFF
--- a/topic/machine-learning/llm-langchain/test.py
+++ b/topic/machine-learning/llm-langchain/test.py
@@ -34,6 +34,11 @@ def test_notebook(request, notebook: str):
 
     Not using `NBRegressionFixture`, because it would manually need to be configured.
     """
+
+    # Skip Vertex AI examples, because authenticating is more complicated.
+    if "vertexai" in str(notebook):
+        raise pytest.skip("Skipping Vertex AI due to lack of authentication")
+
     pytest_notebook(request=request, filepath=notebook)
 
 


### PR DESCRIPTION
## Problem
Authenticating against Vertex AI is apparently more complicated, and currently, CI/GHA does not have corresponding credentials.

## Solution
Just skip the corresponding examples on CI.
