### PR TITLE
TSML: Update to dask 2024.4.1 and mlflow-cratedb 2.11.3

### DIFF
--- a/.github/workflows/ml-automl.yml
+++ b/.github/workflows/ml-automl.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.10' ]
+        python-version: [ '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -2,7 +2,7 @@
 crate[sqlalchemy]
 dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
 joblib<1.4  # Joblib 1.4.0 is not compatible with PyCaret 3.3.0
-mlflow-cratedb==2.10.2
+mlflow-cratedb==2.11.3
 plotly<5.21
 pycaret[models,parallel,test]==3.3.0
 pydantic<2

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -1,5 +1,6 @@
 # Real.
 crate[sqlalchemy]
+dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
 joblib<1.4  # Joblib 1.4.0 is not compatible with PyCaret 3.3.0
 mlflow-cratedb==2.10.2
 plotly<5.21

--- a/topic/machine-learning/mlops-mlflow/requirements.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements.txt
@@ -1,6 +1,6 @@
 # Real.
 dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
-mlflow-cratedb==2.10.2
+mlflow-cratedb==2.11.3
 pydantic<3
 salesforce-merlion>=2,<3
 

--- a/topic/machine-learning/mlops-mlflow/requirements.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements.txt
@@ -1,4 +1,5 @@
 # Real.
+dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
 mlflow-cratedb==2.10.2
 pydantic<3
 salesforce-merlion>=2,<3

--- a/topic/timeseries/requirements.txt
+++ b/topic/timeseries/requirements.txt
@@ -1,5 +1,6 @@
 crate[sqlalchemy]==0.35.2
 cratedb-toolkit[datasets]==0.0.8
+dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
 joblib<1.4  # Joblib 1.4.0 is not compatible with PyCaret 3.3.0
 refinitiv-data<1.7
 pandas<2


### PR DESCRIPTION
## Details

- Python 3.11.9 breaks previous Dask.
- TSML: Use Python 3.11 again, reverting ea3bc2409 from GH-401.