### PR TITLE
TSML: Adjust dependencies around PyCaret/Joblib and Dask

### DIFF
--- a/.github/workflows/timeseries.yml
+++ b/.github/workflows/timeseries.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11.8' ]
+        python-version: [ '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/by-dataframe/dask/requirements.txt
+++ b/by-dataframe/dask/requirements.txt
@@ -1,5 +1,6 @@
 click<9
 colorlog<7
 crate[sqlalchemy]
-dask[dataframe]<=2024.4.1
+dask[dataframe]>=2024.4.1   # Python 3.11.9 breaks previous Dask
+distributed>=2024.4.1       # Python 3.11.9 breaks previous Dask
 pueblo>=0.0.7

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -1,11 +1,8 @@
 # Real.
 crate[sqlalchemy]
-dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
-distributed>=2024.4.1  # Python 3.11.9 breaks previous Dask
-joblib<1.4  # Joblib 1.4.0 is not compatible with PyCaret 3.3.0
 mlflow-cratedb==2.11.3
 plotly<5.21
-pycaret[models,parallel,test]==3.3.0
+pycaret[models,parallel,test]==3.3.1
 pydantic<2
 python-dotenv<2
 

--- a/topic/timeseries/requirements.txt
+++ b/topic/timeseries/requirements.txt
@@ -1,8 +1,7 @@
 crate[sqlalchemy]==0.35.2
 cratedb-toolkit[datasets]==0.0.10
-joblib<1.4  # Joblib 1.4.0 is not compatible with PyCaret 3.3.0
 refinitiv-data<1.7
 pandas<2
-pycaret>=3.0,<3.4
+pycaret==3.3.1
 pydantic<2
 sqlalchemy<2


### PR DESCRIPTION
## About
This patch fixes a few dependency issues, where we needed to add extra version constraints last week, to untrip the situation. With the release of PyCaret 3.3.1, the situation becomes more relaxed again.

## References
- https://github.com/pycaret/pycaret/issues/3966

/cc @marijaselakovic, @ckurze 