### PR TITLE
Fix the `cratedb_rag_customer_support_langchain.ipynb` notebook

### DIFF
--- a/topic/machine-learning/llm-langchain/cratedb_rag_customer_support_langchain.ipynb
+++ b/topic/machine-learning/llm-langchain/cratedb_rag_customer_support_langchain.ipynb
@@ -598,13 +598,6 @@
    "source": [
     "completion.choices[0].message.content"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/topic/machine-learning/llm-langchain/cratedb_rag_customer_support_langchain.ipynb
+++ b/topic/machine-learning/llm-langchain/cratedb_rag_customer_support_langchain.ipynb
@@ -86,7 +86,7 @@
     "#!pip install -r requirements.txt\n",
     "\n",
     "# Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
-    "#!pip install -r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/machine-learning/llm-langchain/requirements.txt\""
+    "#!pip install -r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/machine-learning/llm-langchain/requirements.txt"
    ]
   },
   {


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

1. There was a closing double quote around the URL at `pip install`, but no opening one
2. Colab was not able to resolve dependencies within 30 minutes. Removing optional, but unused, `pueblo` dependencies fixed it.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
