### PR TITLE
ML: Use `testbook` instead of `pytest-notebook`

### DIFF
--- a/.github/workflows/dataframe-dask.yml
+++ b/.github/workflows/dataframe-dask.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/dataframe-pandas.yml
+++ b/.github/workflows/dataframe-pandas.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/ml-automl.yml
+++ b/.github/workflows/ml-automl.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11' ]
+        python-version: [ '3.10', '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/ml-langchain.yml
+++ b/.github/workflows/ml-langchain.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11' ]
+        python-version: [ '3.10', '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/ml-mlflow.yml
+++ b/.github/workflows/ml-mlflow.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11' ]
+        python-version: [ '3.10', '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/.github/workflows/timeseries.yml
+++ b/.github/workflows/timeseries.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.11' ]
+        python-version: [ '3.10', '3.11' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/topic/machine-learning/automl/pyproject.toml
+++ b/topic/machine-learning/automl/pyproject.toml
@@ -19,38 +19,6 @@ xfail_strict = true
 markers = [
 ]
 
-# pytest-notebook settings
-nb_test_files = true
-nb_coverage = false
-# Default cell timeout is 120 seconds. For heavy computing, it needs to be increased.
-nb_exec_timeout = 240
-nb_diff_replace = [
-    # Compensate output of `crash`.
-    '"/cells/*/outputs/*/text" "\(\d.\d+ sec\)" "(0.000 sec)"',
-    # Compensate other outputs.
-    '"/cells/*/outputs/*/data/text/html" "T_....." "T_na"',
-    '"/cells/*/outputs/*/data/text/plain" "IPython.core.display.HTML object" "pandas.io.formats.style.Styler"',
-    '"/cells/*/outputs/*/data/text/plain" "pandas.io.formats.style.Styler at 0x.+" "pandas.io.formats.style.Styler"',
-    '"/cells/*/outputs/*/data/application/vnd.jupyter.widget-view+json" "model_id: .+" "model_id: na"',
-    '"/cells/*/outputs/*/data/text/html" "\>\d+\.\d+\<\/td\>" "0.3333"',
-]
-# `vector_search.py` does not include any output(s).
-nb_diff_ignore = [
-    "/metadata/language_info",
-    "/metadata/widgets",
-    "/cells/*/execution_count",
-    "/cells/*/outputs/*/execution_count",
-    "/cells/*/outputs/*/metadata/nbreg",
-    # Ignore images.
-    "/cells/*/outputs/*/data/image/png",
-    # Ignore all cell output. It is too tedious to compare and maintain.
-    # The validation hereby extends exclusively to the _execution_ of notebook cells,
-    # able to catch syntax errors, module import flaws, and runtime errors.
-    # However, the validation will not catch any regressions on actual cell output,
-    # or whether any output is produced at all.
-    "/cells/*/outputs",
-]
-
 [tool.coverage.run]
 branch = false
 

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -5,6 +5,7 @@ plotly<5.21
 pycaret[models,parallel,test]==3.3.1
 pydantic<2
 python-dotenv<2
+sqlalchemy==2.*
 
 # Development.
 # mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/automl/test.py
+++ b/topic/machine-learning/automl/test.py
@@ -22,8 +22,10 @@ from pathlib import Path
 
 import pytest
 from cratedb_toolkit.util import DatabaseAdapter
-from pueblo.testing.folder import str_list, list_notebooks, list_python_files
-from pueblo.testing.snippet import pytest_notebook, pytest_module_function
+from pueblo.testing.folder import str_list, list_python_files
+from pueblo.testing.notebook import generate_tests
+from pueblo.testing.snippet import pytest_module_function
+from testbook import testbook
 
 HERE = Path(__file__).parent
 
@@ -57,15 +59,20 @@ def churn_dataset(cratedb):
     cratedb.run_sql("REFRESH TABLE pycaret_churn;")
 
 
-@pytest.mark.parametrize("notebook", str_list(list_notebooks(HERE)))
-def test_notebook(request, notebook: str):
+def pytest_generate_tests(metafunc):
     """
-    From individual Jupyter Notebook file, collect cells as pytest
-    test cases, and run them.
+    Generate pytest test case per Jupyter Notebook.
+    """
+    here = Path(__file__).parent
+    generate_tests(metafunc, path=here)
 
-    Not using `NBRegressionFixture`, because it would manually need to be configured.
+
+def test_notebook(notebook):
     """
-    pytest_notebook(request=request, filepath=notebook)
+    Execute Jupyter Notebook, one test case per .ipynb file.
+    """
+    with testbook(notebook) as tb:
+        tb.execute()
 
 
 @pytest.mark.parametrize("pyfile", str_list(list_python_files(HERE)))

--- a/topic/machine-learning/llm-langchain/conftest.py
+++ b/topic/machine-learning/llm-langchain/conftest.py
@@ -1,6 +1,0 @@
-# Initialize nltk upfront, so that it does not run stray output into Jupyter Notebooks.
-from pueblo.testing.nlp import nltk_init
-
-# Make `pytest.exit()` called in notebook cells gracefully skip testing the whole notebook.
-from pueblo.testing.notebook import monkeypatch_pytest_notebook_treat_cell_exit_as_notebook_skip
-monkeypatch_pytest_notebook_treat_cell_exit_as_notebook_skip()

--- a/topic/machine-learning/llm-langchain/pyproject.toml
+++ b/topic/machine-learning/llm-langchain/pyproject.toml
@@ -19,24 +19,6 @@ xfail_strict = true
 markers = [
 ]
 
-# pytest-notebook settings
-nb_test_files = true
-nb_coverage = true
-nb_diff_replace = [
-    # Compensate output of `crash`.
-    '"/cells/*/outputs/*/text" "\(\d.\d+ sec\)" "(0.000 sec)"',
-]
-# `vector_search.py` does not include any output(s).
-nb_diff_ignore = [
-    "/metadata/language_info",
-    "/cells/*/execution_count",
-    "/cells/*/outputs/*/execution_count",
-
-    # Do not compare details of cell outputs.
-    # It is impossible to maintain efficiently.
-    "/cells/*/outputs",
-]
-
 [tool.coverage.run]
 branch = false
 

--- a/topic/machine-learning/llm-langchain/requirements.txt
+++ b/topic/machine-learning/llm-langchain/requirements.txt
@@ -11,6 +11,7 @@ pydantic>=1,<3
 pypdf<5
 python-dotenv<2
 requests-cache<2
+sqlalchemy==2.*
 unstructured<0.12
 google-cloud-aiplatform
 langchain-google-vertexai

--- a/topic/machine-learning/mlops-mlflow/pyproject.toml
+++ b/topic/machine-learning/mlops-mlflow/pyproject.toml
@@ -18,22 +18,6 @@ xfail_strict = true
 markers = [
 ]
 
-# pytest-notebook settings
-nb_test_files = true
-nb_coverage = true
-nb_diff_replace = [
-    # Compensate output of `crash`.
-    '"/cells/*/outputs/*/text" "\(\d.\d+ sec\)" "(0.000 sec)"',
-]
-# `vector_search.py` does not include any output(s).
-nb_diff_ignore = [
-    "/metadata/language_info",
-    "/cells/*/execution_count",
-    "/cells/*/outputs/*/execution_count",
-    # Ignore images.
-    "/cells/*/outputs/*/data/image/png",
-]
-
 [tool.coverage.run]
 branch = false
 

--- a/topic/machine-learning/mlops-mlflow/requirements.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements.txt
@@ -4,6 +4,7 @@ distributed>=2024.4.1  # Python 3.11.9 breaks previous Dask
 mlflow-cratedb==2.11.3
 pydantic<3
 salesforce-merlion>=2,<3
+sqlalchemy==2.*
 
 # Development.
 # mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/mlops-mlflow/test.py
+++ b/topic/machine-learning/mlops-mlflow/test.py
@@ -3,8 +3,10 @@ from pathlib import Path
 import pytest
 
 from cratedb_toolkit.util import DatabaseAdapter
-from pueblo.testing.folder import str_list, list_notebooks, list_python_files
-from pueblo.testing.snippet import pytest_module_function, pytest_notebook
+from pueblo.testing.folder import str_list, list_python_files
+from pueblo.testing.notebook import generate_tests
+from pueblo.testing.snippet import pytest_module_function
+from testbook import testbook
 
 HERE = Path(__file__).parent
 
@@ -22,15 +24,20 @@ def db_init(cratedb):
     cratedb.run_sql("DROP TABLE IF EXISTS machine_data;")
 
 
-@pytest.mark.parametrize("notebook", str_list(list_notebooks(HERE)))
-def test_notebook(request, notebook: str):
+def pytest_generate_tests(metafunc):
     """
-    From individual Jupyter Notebook file, collect cells as pytest
-    test cases, and run them.
+    Generate pytest test case per Jupyter Notebook.
+    """
+    here = Path(__file__).parent
+    generate_tests(metafunc, path=here)
 
-    Not using `NBRegressionFixture`, because it would manually need to be configured.
+
+def test_notebook(notebook):
     """
-    pytest_notebook(request=request, filepath=notebook)
+    Execute Jupyter Notebook, one test case per .ipynb file.
+    """
+    with testbook(notebook) as tb:
+        tb.execute()
 
 
 @pytest.mark.parametrize("pyfile", str_list(list_python_files(HERE)))

--- a/topic/timeseries/conftest.py
+++ b/topic/timeseries/conftest.py
@@ -27,6 +27,7 @@ def reset_database_tables():
 
     reset_tables = [
         "cities",
+        "machine_data",
         "weather_data",
         "weather_stations",
     ]

--- a/topic/timeseries/exploratory_data_analysis.ipynb
+++ b/topic/timeseries/exploratory_data_analysis.ipynb
@@ -45,7 +45,7 @@
     "#!pip install -r requirements.txt\n",
     "\n",
     "# Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
-    "#!pip install -r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/timeseries/requirements.txt"
+    "#!pip install -r https://github.com/crate/cratedb-examples/raw/main/topic/timeseries/requirements.txt"
    ]
   },
   {

--- a/topic/timeseries/time-series-decomposition.ipynb
+++ b/topic/timeseries/time-series-decomposition.ipynb
@@ -49,7 +49,7 @@
     "#!pip install -r requirements.txt\n",
     "\n",
     "# Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
-    "#!pip install -r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/timeseries/requirements.txt"
+    "#!pip install -r https://github.com/crate/cratedb-examples/raw/main/topic/timeseries/requirements.txt"
    ]
   },
   {

--- a/topic/timeseries/timeseries-anomaly-detection.ipynb
+++ b/topic/timeseries/timeseries-anomaly-detection.ipynb
@@ -110,11 +110,14 @@
     "\n",
     "engine = sa.create_engine(CONNECTION_STRING, echo=os.environ.get('DEBUG'))\n",
     "\n",
-    "query_create_table = 'CREATE TABLE machine_data (\"timestamp\" TIMESTAMP, \"value\" DOUBLE PRECISION)' \n",
-    "query_copy_from = \"COPY machine_data FROM 'https://github.com/crate/cratedb-datasets/raw/main/timeseries/nab-machine-failure.csv';\"\n",
+    "sql_ddl = 'CREATE TABLE machine_data (\"timestamp\" TIMESTAMP, \"value\" DOUBLE PRECISION)'\n",
+    "sql_load = \"COPY machine_data FROM 'https://github.com/crate/cratedb-datasets/raw/main/timeseries/nab-machine-failure.csv';\"\n",
+    "sql_refresh = \"REFRESH TABLE machine_data;\"\n",
+    "\n",
     "with engine.connect() as conn:\n",
-    "    conn.execute(sa.text(query_create_table))\n",
-    "    conn.execute(sa.text(query_copy_from))\n"
+    "    conn.execute(sa.text(sql_ddl))\n",
+    "    conn.execute(sa.text(sql_load))\n",
+    "    conn.execute(sa.text(sql_refresh))"
    ]
   },
   {

--- a/topic/timeseries/timeseries-anomaly-detection.ipynb
+++ b/topic/timeseries/timeseries-anomaly-detection.ipynb
@@ -46,7 +46,7 @@
     "%pip install -r requirements.txt\n",
     "\n",
     "# Note: If you are running in an environment like Google Colab, please use the absolute path of the requirements:\n",
-    "#%pip install -r https://raw.githubusercontent.com/crate/cratedb-examples/main/topic/timeseries/requirements.txt"
+    "#%pip install -r https://github.com/crate/cratedb-examples/raw/main/topic/timeseries/requirements.txt"
    ]
   },
   {


### PR DESCRIPTION
## About

The `topic/timeseries` slot already started using the `testbook` package for testing. This patch also makes the other notebook testing code in `topic/machine-learning` use [testbook](https://pypi.org/project/testbook/) instead of [pytest-notebook](https://pypi.org/project/pytest_notebook/), what has been used before.
