### PR TITLE
TypeORM: ID column to string to support UUID

### DIFF
--- a/by-language/javascript-typeorm/src/controller/UserController.ts
+++ b/by-language/javascript-typeorm/src/controller/UserController.ts
@@ -11,7 +11,7 @@ export class UserController {
     }
 
     async one(request: Request, response: Response, next: NextFunction) {
-        const id = parseInt(request.params.id)
+        const id = request.params.id
 
 
         const user = await this.userRepository.findOne({
@@ -37,7 +37,7 @@ export class UserController {
     }
 
     async remove(request: Request, response: Response, next: NextFunction) {
-        const id = parseInt(request.params.id)
+        const id = request.params.id
 
         let userToRemove = await this.userRepository.findOneBy({ id })
 

--- a/by-language/javascript-typeorm/src/entity/User.ts
+++ b/by-language/javascript-typeorm/src/entity/User.ts
@@ -4,7 +4,7 @@ import { Entity, PrimaryGeneratedColumn, Column } from "typeorm"
 export class User {
 
     @PrimaryGeneratedColumn("uuid")
-    id: number
+    id: string
 
     @Column()
     firstName: string


### PR DESCRIPTION
## About
Adjust example about that primary autogenerated keys with CrateDB are UUIDs, stored as strings.

## References
This example uses those other dialect patches needed to make TypeORM compatible with CrateDB.
- https://github.com/crate-workbench/typeorm/pull/1
- https://github.com/crate-workbench/typeorm/pull/2

It is also stacked upon this one.
- GH-187
