### PR TITLE
CI/Testing: Use macOS 13 on GHA

### DIFF
--- a/.github/workflows/testing-native-python.yml
+++ b/.github/workflows/testing-native-python.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'macos-latest' ]
+        os: [ 'ubuntu-latest', 'macos-13' ]
         python-version: [ '3.7', '3.12' ]
         cratedb-version: [ 'nightly' ]
 


### PR DESCRIPTION
## Problem
macos-14 aka. macos-latest has switched to being an ARM runner. In turn, this one only supports higher versions of Python than currently designated.

## Solution
Thus, switching to a compatible runner, macos-13.
