### PR TITLE
Chore: Update CI to use Npgsql 6.0.11, 7.0.7, and 8.0.3

### DIFF
--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         dotnet-version: [ '6.0.x', '7.0.x', '8.0.x' ]
-        npgsql-version: [ '6.0.10', '7.0.6', '8.0.2' ]
+        npgsql-version: [ '6.0.11', '7.0.7', '8.0.3' ]
         cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers


### PR DESCRIPTION
## About
Npgsql v8.0.3 has been released last week.

https://github.com/npgsql/npgsql/releases/tag/v8.0.3

## More
- Supersedes GH-451.