### PR TITLE
Chore: Fix LangChain import warning

### DIFF
--- a/topic/machine-learning/llm-langchain/cratedb-vectorstore-rag-openai-sql.ipynb
+++ b/topic/machine-learning/llm-langchain/cratedb-vectorstore-rag-openai-sql.ipynb
@@ -302,6 +302,7 @@
     }
    ],
    "source": [
+    "from langchain_openai import OpenAIEmbeddings\n",
     "embeddings = OpenAIEmbeddings()\n",
     "pages_text = [doc.page_content for doc in pages]\n",
     "pages_embeddings = embeddings.embed_documents(pages_text)\n",


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
In the original code you get the following warning:
LangChainDeprecationWarning: The class `langchain_community.embeddings.openai.OpenAIEmbeddings` was deprecated in langchain-community 0.1.0 and will be removed in 0.2.0. 
An updated version of the class exists in the langchain-openai package and should be used instead. 
To use it run `pip install -U langchain-openai` and import as `from langchain_openai import OpenAIEmbeddings`.

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 

