### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/application/apache-superset/requirements.txt
+++ b/application/apache-superset/requirements.txt
@@ -1,2 +1,2 @@
 apache-superset
-crate[sqlalchemy]==0.35.2
+sqlalchemy-cratedb>=0.36.1,<1

--- a/by-dataframe/dask/README.md
+++ b/by-dataframe/dask/README.md
@@ -22,7 +22,7 @@ database table in a single operation. It can be used like this:
 # DBURI = "crate://crate@localhost:4200/"
 
 import sqlalchemy as sa
-from crate.client.sqlalchemy.support import insert_bulk
+from sqlalchemy_cratedb.support import insert_bulk
 
 ddf.to_sql(
     "testdrive",

--- a/by-dataframe/dask/insert_dask.py
+++ b/by-dataframe/dask/insert_dask.py
@@ -8,7 +8,7 @@ Setup
 =====
 ::
 
-    pip install --upgrade click colorlog 'crate[sqlalchemy]' pandas
+    pip install --upgrade click colorlog pandas sqlalchemy-cratedb
 
 Synopsis
 ========
@@ -21,11 +21,10 @@ import logging
 
 import click
 import dask.dataframe as dd
-import sqlalchemy as sa
-from crate.client.sqlalchemy.support import insert_bulk
 from dask.diagnostics import ProgressBar
 from pueblo.testing.pandas import makeTimeDataFrame
 from pueblo.util.logging import setup_logging
+from sqlalchemy_cratedb.support import insert_bulk
 
 logger = logging.getLogger(__name__)
 

--- a/by-dataframe/dask/requirements.txt
+++ b/by-dataframe/dask/requirements.txt
@@ -1,6 +1,6 @@
 click<9
 colorlog<7
-crate[sqlalchemy]
 dask[dataframe]>=2024.4.1   # Python 3.11.9 breaks previous Dask
 distributed>=2024.4.1       # Python 3.11.9 breaks previous Dask
 pueblo>=0.0.7
+sqlalchemy-cratedb>=0.36.1,<1

--- a/by-dataframe/pandas/README.md
+++ b/by-dataframe/pandas/README.md
@@ -22,7 +22,7 @@ database table in a single operation. It can be used like this:
 # DBURI = "crate://crate@localhost:4200/"
 
 import sqlalchemy as sa
-from crate.client.sqlalchemy.support import insert_bulk
+from sqlalchemy_cratedb.support import insert_bulk
 
 engine = sa.create_engine(DBURI, **kwargs)
 df.to_sql(

--- a/by-dataframe/pandas/insert_pandas.py
+++ b/by-dataframe/pandas/insert_pandas.py
@@ -16,7 +16,7 @@ Setup
 =====
 ::
 
-    pip install --upgrade click colorlog 'crate[sqlalchemy]' pandas
+    pip install --upgrade click colorlog pandas sqlalchemy-cratedb
 
 
 Synopsis
@@ -50,9 +50,9 @@ import logging
 
 import click
 import sqlalchemy as sa
-from crate.client.sqlalchemy.support import insert_bulk
 from pueblo.testing.pandas import makeTimeDataFrame
 from pueblo.util.logging import setup_logging
+from sqlalchemy_cratedb.support import insert_bulk
 
 logger = logging.getLogger(__name__)
 

--- a/by-dataframe/pandas/requirements.txt
+++ b/by-dataframe/pandas/requirements.txt
@@ -1,5 +1,5 @@
 click<9
 colorlog<7
-crate[sqlalchemy]
-pandas<2.3
+pandas==2.2.*
 pueblo>=0.0.7
+sqlalchemy-cratedb>=0.36.1,<1

--- a/by-dataframe/polars/read_sqlalchemy.py
+++ b/by-dataframe/polars/read_sqlalchemy.py
@@ -1,9 +1,7 @@
 """
-Install the dependencies with:
+Install the dependencies to run this program::
 
-```
-$ pip install crate[sqlalchemy] polars
-```
+    pip install --upgrade polars sqlalchemy-cratedb
 """
 
 import polars

--- a/by-dataframe/polars/write_sqlalchemy.py
+++ b/by-dataframe/polars/write_sqlalchemy.py
@@ -1,9 +1,9 @@
 """
 Import a parquet file into CrateDB using polars + sqlalchemy
 
-Install the dependencies with to run this script:
+Install the dependencies to run this program::
 
-`$ pip install polars pandas crate[sqlalchemy] pyarrow`
+    pip install --upgrade pandas polars pyarrow sqlalchemy-cratedb
 """
 
 import polars

--- a/by-language/python-sqlalchemy/insert_efficient.py
+++ b/by-language/python-sqlalchemy/insert_efficient.py
@@ -14,7 +14,7 @@ Setup
 =====
 ::
 
-    pip install --upgrade 'crate[sqlalchemy]'
+    pip install --upgrade sqlalchemy-cratedb
 
 
 Synopsis

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -1,11 +1,12 @@
 # Real.
-crate[sqlalchemy]
-mlflow-cratedb==2.11.3
+cratedb-toolkit>=0.0.13,<0.1
+mlflow-cratedb==2.13.2
 plotly<5.23
 pycaret[models,parallel,test]==3.3.2
 pydantic<2
 python-dotenv<2
 sqlalchemy==2.*
+sqlalchemy-cratedb>=0.36.1,<1
 
 # Development.
 # mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/llm-langchain/requirements.txt
+++ b/topic/machine-learning/llm-langchain/requirements.txt
@@ -1,11 +1,6 @@
 # Real.
 crash
-crate[sqlalchemy]==0.35.2
-cratedb-toolkit==0.0.12
-
-# langchain[cratedb,openai]==0.0.354
-# langchain-community==0.0.8
-
+cratedb-toolkit>=0.0.13,<0.1
 google-cloud-aiplatform<2
 langchain-google-vertexai<2
 langchain-openai<0.2
@@ -17,6 +12,7 @@ python-dotenv<2
 requests<3
 requests-cache<2
 sqlalchemy==2.*
+sqlalchemy-cratedb>=0.36.1,<1
 unstructured<0.15
 
 # Development.

--- a/topic/machine-learning/mlops-mlflow/requirements.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements.txt
@@ -1,7 +1,7 @@
 # Real.
 dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
 distributed>=2024.4.1  # Python 3.11.9 breaks previous Dask
-mlflow-cratedb==2.11.3
+mlflow-cratedb==2.13.2
 pydantic<3
 salesforce-merlion>=2,<3
 sqlalchemy==2.*

--- a/topic/timeseries/dask-weather-data-import.ipynb
+++ b/topic/timeseries/dask-weather-data-import.ipynb
@@ -66,7 +66,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install dask 'pandas==2.0.0' 'crate[sqlalchemy]' 'cratedb-toolkit==0.0.10' 'pueblo>=0.0.7' kaggle"
+    "!pip install --upgrade 'cratedb-toolkit' 'dask' 'kaggle' 'pandas==2.0.*' 'pueblo>=0.0.7' 'sqlalchemy-cratedb'"
    ]
   },
   {
@@ -531,7 +531,7 @@
    "source": [
     "import os\n",
     "import sqlalchemy as sa\n",
-    "from crate.client.sqlalchemy.support import insert_bulk\n",
+    "from sqlalchemy_cratedb.support import insert_bulk\n",
     "\n",
     "# Define database address when using CrateDB Cloud.\n",
     "# Please find these settings on your cluster overview page.\n",

--- a/topic/timeseries/requirements.txt
+++ b/topic/timeseries/requirements.txt
@@ -1,7 +1,7 @@
-crate[sqlalchemy]==0.35.2
-cratedb-toolkit[datasets]==0.0.12
+cratedb-toolkit[datasets]==0.0.13
 refinitiv-data<1.7
-pandas<2
+pandas==1.*
 pycaret==3.3.2
 pydantic<2
-sqlalchemy<2
+sqlalchemy==1.*
+sqlalchemy-cratedb>=0.36.1,<1

--- a/topic/timeseries/timeseries-queries-and-visualization.ipynb
+++ b/topic/timeseries/timeseries-queries-and-visualization.ipynb
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#!pip install 'crate[sqlalchemy]' 'pandas>=2' plotly kaleido"
+    "#!pip install --upgrade kaleido 'pandas>=2' plotly sqlalchemy-cratedb"
    ]
   },
   {


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch verifies and concludes the migration.

## References
- https://github.com/crate/roadmap/issues/85

/cc @karynzv, @hlcianfagna, @wierdvanderhaar, @matriv, @seut 