### PR TITLE
PHP/AMPHP: Update to amphp/amp v3 by switching to `Revolt\EventLoop`

### DIFF
--- a/.github/workflows/lang-php-amphp.yml
+++ b/.github/workflows/lang-php-amphp.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        php-version: [ '7.4', '8.2', '8.3' ]
+        php-version: [ '8.1', '8.2', '8.3' ]
         cratedb-version: [ 'nightly' ]
 
     services:

--- a/by-language/php-amphp/basic.php
+++ b/by-language/php-amphp/basic.php
@@ -27,8 +27,8 @@ error_reporting(E_ALL);
 
 require __DIR__ . '/vendor/autoload.php';
 
-use Amp\Loop;
 use Amp\Postgres;
+use Revolt\EventLoop;
 
 
 function print_header($title)
@@ -58,7 +58,7 @@ class DatabaseWorkload
 
         print_header("Display all settings using `SHOW ALL`");
 
-        Loop::run(function () {
+        EventLoop::run(function () {
 
             // Connect to CrateDB's PostgreSQL interface.
             $config = Postgres\ConnectionConfig::fromString($this->dsn);
@@ -85,7 +85,7 @@ class DatabaseWorkload
 
         print_header("Run DDL, DML, and DQL statements subsequently");
 
-        Loop::run(function () {
+        EventLoop::run(function () {
 
             // Connect to CrateDB's PostgreSQL interface.
             $config = Postgres\ConnectionConfig::fromString($this->dsn);
@@ -132,7 +132,7 @@ class DatabaseWorkload
 
         print_header("Using a connection pool");
 
-        Loop::run(function () {
+        EventLoop::run(function () {
 
             // Connect to CrateDB's PostgreSQL interface, using a connection pool.
             $config = Postgres\ConnectionConfig::fromString($this->dsn);

--- a/by-language/php-amphp/composer.json
+++ b/by-language/php-amphp/composer.json
@@ -14,7 +14,7 @@
     "keywords": ["database", "cratedb", "sql"],
     "require": {
         "php":     "^7.1|^8.0|^8.1|^8.2",
-        "amphp/postgres": "^1.4"
+        "amphp/postgres": "^2.0"
     },
     "scripts": {
         "test": "php basic.php 'host=localhost port=5432 user=crate'"

--- a/by-language/php-amphp/composer.json
+++ b/by-language/php-amphp/composer.json
@@ -13,7 +13,7 @@
     "homepage": "https://github.com/crate/cratedb-examples/tree/main/by-language/php-amphp",
     "keywords": ["database", "cratedb", "sql"],
     "require": {
-        "php":     "^7.1|^8.0|^8.1|^8.2",
+        "php":     "^8.1|^8.2|^8.3",
         "amphp/postgres": "^2.0"
     },
     "scripts": {

--- a/by-language/php-amphp/composer.lock
+++ b/by-language/php-amphp/composer.lock
@@ -4,47 +4,40 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb391a75ea9d945d754265fd2e505008",
+    "content-hash": "881cee6df06f24ce2a25b3d76d1176ff",
     "packages": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.2",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb"
+                "reference": "138801fb68cfc9c329da8a7b39d01ce7291ee4b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
-                "reference": "9d5100cebffa729aaffecd3ad25dc5aeea4f13bb",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/138801fb68cfc9c329da8a7b39d01ce7291ee4b0",
+                "reference": "138801fb68cfc9c329da8a7b39d01ce7291ee4b0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "amphp/phpunit-util": "^1",
-                "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^7 | ^8 | ^9",
-                "psalm/phar": "^3.11@dev",
-                "react/promise": "^2"
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "lib/functions.php",
-                    "lib/Internal/functions.php"
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
                 ],
                 "psr-4": {
-                    "Amp\\": "lib"
+                    "Amp\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -52,10 +45,6 @@
                 "MIT"
             ],
             "authors": [
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                },
                 {
                     "name": "Aaron Piotrowski",
                     "email": "aaron@trowski.com"
@@ -67,6 +56,10 @@
                 {
                     "name": "Niklas Keller",
                     "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
                 }
             ],
             "description": "A non-blocking concurrency framework for PHP applications.",
@@ -83,9 +76,8 @@
                 "promise"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.2"
+                "source": "https://github.com/amphp/amp/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -93,34 +85,103 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-20T17:52:18+00:00"
+            "time": "2024-05-10T21:37:46+00:00"
         },
         {
-            "name": "amphp/postgres",
-            "version": "v1.4.5",
+            "name": "amphp/pipeline",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/amphp/postgres.git",
-                "reference": "8e45076ac65870d58e2fe206ca23f3546b60bf03"
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "f1c2ce35d27ae86ead018adb803eccca7421dd9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/postgres/zipball/8e45076ac65870d58e2fe206ca23f3546b60bf03",
-                "reference": "8e45076ac65870d58e2fe206ca23f3546b60bf03",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/f1c2ce35d27ae86ead018adb803eccca7421dd9b",
+                "reference": "f1c2ce35d27ae86ead018adb803eccca7421dd9b",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2",
-                "amphp/sql": "^1",
-                "amphp/sql-common": "^1",
-                "php": ">=7.1"
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "amphp/phpunit-util": "^1.1.2",
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-10T14:48:16+00:00"
+        },
+        {
+            "name": "amphp/postgres",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/postgres.git",
+                "reference": "4fffbb2087e40ccaf779acdb27ca021d8718308d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/postgres/zipball/4fffbb2087e40ccaf779acdb27ca021d8718308d",
+                "reference": "4fffbb2087e40ccaf779acdb27ca021d8718308d",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/sql": "^2",
+                "amphp/sql-common": "^2",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
                 "ext-pgsql": "*",
                 "ext-pq": "*",
-                "phpunit/phpunit": "^8 | ^7"
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
             },
             "type": "library",
             "autoload": {
@@ -143,7 +204,7 @@
                 }
             ],
             "description": "Asynchronous PostgreSQL client for Amp.",
-            "homepage": "http://amphp.org",
+            "homepage": "https://amphp.org",
             "keywords": [
                 "async",
                 "asynchronous",
@@ -155,7 +216,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/postgres/issues",
-                "source": "https://github.com/amphp/postgres/tree/v1.4.5"
+                "source": "https://github.com/amphp/postgres/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -163,29 +224,30 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-06T04:36:07+00:00"
+            "time": "2024-03-10T17:02:44+00:00"
         },
         {
             "name": "amphp/sql",
-            "version": "v1.0.2",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/sql.git",
-                "reference": "5a1dcfd9a3c3518826c616b4d0b0fa0363f087fa"
+                "reference": "4cf80b477b5d40089ba2c162373a604e06d57d7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/sql/zipball/5a1dcfd9a3c3518826c616b4d0b0fa0363f087fa",
-                "reference": "5a1dcfd9a3c3518826c616b4d0b0fa0363f087fa",
+                "url": "https://api.github.com/repos/amphp/sql/zipball/4cf80b477b5d40089ba2c162373a604e06d57d7b",
+                "reference": "4cf80b477b5d40089ba2c162373a604e06d57d7b",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2",
-                "php": ">=7.1"
+                "amphp/amp": "^3",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "phpunit/phpunit": "^8"
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
             },
             "type": "library",
             "autoload": {
@@ -198,7 +260,7 @@
                 "MIT"
             ],
             "description": "Asynchronous SQL client for Amp.",
-            "homepage": "http://amphp.org",
+            "homepage": "https://amphp.org",
             "keywords": [
                 "async",
                 "asynchronous",
@@ -208,7 +270,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/sql/issues",
-                "source": "https://github.com/amphp/sql/tree/v1.0.2"
+                "source": "https://github.com/amphp/sql/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -216,31 +278,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-12-18T22:54:18+00:00"
+            "time": "2024-03-10T15:03:32+00:00"
         },
         {
             "name": "amphp/sql-common",
-            "version": "v1.1.4",
+            "version": "v2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/sql-common.git",
-                "reference": "6ed5b96d26528bd56213ebb867a2992e7a0b8278"
+                "reference": "996b8ad67410a20f0df0e2315a174b4c58f21e1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/sql-common/zipball/6ed5b96d26528bd56213ebb867a2992e7a0b8278",
-                "reference": "6ed5b96d26528bd56213ebb867a2992e7a0b8278",
+                "url": "https://api.github.com/repos/amphp/sql-common/zipball/996b8ad67410a20f0df0e2315a174b4c58f21e1a",
+                "reference": "996b8ad67410a20f0df0e2315a174b4c58f21e1a",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2",
-                "amphp/sql": "^1",
-                "php": ">=7"
+                "amphp/amp": "^3",
+                "amphp/sql": "^2",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "amphp/phpunit-util": "^1.3",
-                "phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
             },
             "type": "library",
             "autoload": {
@@ -253,7 +316,7 @@
                 "MIT"
             ],
             "description": "Common classes for non-blocking SQL implementations.",
-            "homepage": "http://amphp.org",
+            "homepage": "https://amphp.org",
             "keywords": [
                 "async",
                 "asynchronous",
@@ -263,7 +326,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/sql-common/issues",
-                "source": "https://github.com/amphp/sql-common/tree/v1.1.4"
+                "source": "https://github.com/amphp/sql-common/tree/v2.0.0"
             },
             "funding": [
                 {
@@ -271,7 +334,79 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-06T04:22:36+00:00"
+            "time": "2024-03-10T15:22:18+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/25de49af7223ba039f64da4ae9a28ec2d10d0254",
+                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.6"
+            },
+            "time": "2023-11-30T05:34:44+00:00"
         }
     ],
     "packages-dev": [],
@@ -284,5 +419,5 @@
         "php": "^7.1|^8.0|^8.1|^8.2"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/by-language/php-amphp/composer.lock
+++ b/by-language/php-amphp/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "881cee6df06f24ce2a25b3d76d1176ff",
+    "content-hash": "e22eb416c11d5686d99a3a09eadc5a55",
     "packages": [
         {
             "name": "amphp/amp",
@@ -416,7 +416,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1|^8.0|^8.1|^8.2"
+        "php": "^8.1|^8.2|^8.3"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
## About
- Updates to amphp/amp 3.x. -- https://amphp.org/amp
- Includes and extends GH-487.

## Trivia
- Remove support for PHP 7. Add support for PHP 8.3.