### PR TITLE
ML/LLM: Optimize LangChain installation extras

### DIFF
--- a/topic/machine-learning/llm-langchain/requirements.txt
+++ b/topic/machine-learning/llm-langchain/requirements.txt
@@ -17,6 +17,6 @@ unstructured<0.15
 
 # Development.
 # cratedb-toolkit @ git+https://github.com/crate-workbench/cratedb-toolkit.git@main
-langchain[cratedb,openai] @ git+https://github.com/crate-workbench/langchain.git@cratedb#subdirectory=libs/langchain
+langchain @ git+https://github.com/crate-workbench/langchain.git@cratedb#subdirectory=libs/langchain
 langchain-community @ git+https://github.com/crate-workbench/langchain.git@cratedb#subdirectory=libs/community
 # pueblo[cli,fileio,nlp] @ git+https://github.com/pyveci/pueblo.git@main


### PR DESCRIPTION
## Problem
Reported by @wierdvanderhaar per GH-480. Thank you.
```
WARNING: langchain 0.2.3 does not provide the extra 'cratedb'
WARNING: langchain 0.2.3 does not provide the extra 'openai'
```

## Evaluation
LangChain does not provide `extra` labels for community dependencies any longer.
