### PR TITLE
Dependencies: Update to mlflow-cratedb 2.14.1

### DIFF
--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -1,12 +1,11 @@
 # Real.
-cratedb-toolkit==0.0.14
-mlflow-cratedb==2.14.0
+mlflow-cratedb==2.14.1
 plotly<5.23
 pycaret[models,parallel,test]==3.3.2
 pydantic<2
 python-dotenv<2
 sqlalchemy==2.*
-sqlalchemy-cratedb==0.37.0
+sqlalchemy-cratedb==0.38.0
 
 # Development.
 # mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/machine-learning/mlops-mlflow/requirements.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements.txt
@@ -1,7 +1,7 @@
 # Real.
 dask>=2024.4.1  # Python 3.11.9 breaks previous Dask
 distributed>=2024.4.1  # Python 3.11.9 breaks previous Dask
-mlflow-cratedb==2.14.0
+mlflow-cratedb==2.14.1
 pydantic<3
 salesforce-merlion>=2,<3
 sqlalchemy==2.*


### PR DESCRIPTION
## About
Update dependencies to use MLflow 2.14.1, released 5 days ago.

-- https://github.com/crate/mlflow-cratedb/releases/tag/v2.14.1
