### PR TITLE
Kafka/Flink: Fix DDL statement

### DIFF
--- a/application/apache-kafka-flink-streaming/README.md
+++ b/application/apache-kafka-flink-streaming/README.md
@@ -40,7 +40,7 @@ into your local `.env` file.
 ### Run the docker compose (and build the images)
 
 ```
-docker compose up -d --build
+docker-compose up -d --build
 ```
 
 ### Stop the docker compose
@@ -111,7 +111,7 @@ Create the table in CrateDB:
 
 ```sql
 CREATE TABLE IF NOT EXISTS "doc"."weather_flink_sink" (
-  "inserted_at" TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  "inserted_at" TIMESTAMP WITH TIME ZONE NOT NULL GENERATED ALWAYS AS now(),
   "location" OBJECT(DYNAMIC),
   "current" OBJECT(DYNAMIC)
 )


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
docker-compose is a separate executable nowadays.  
The ingest from Flink fails when you use the old create table statement because only location and current are ingested. With these generated columns, we are sure that the ingests are successful. 


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): 
 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
