### PR TITLE
Testing: Drop support for Python 3.7

### DIFF
--- a/.github/workflows/testing-native-python.yml
+++ b/.github/workflows/testing-native-python.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'macos-13' ]
-        python-version: [ '3.7', '3.12' ]
+        python-version: [ '3.8', '3.12' ]
         cratedb-version: [ 'nightly' ]
 
     steps:

--- a/.github/workflows/testing-testcontainers-python.yml
+++ b/.github/workflows/testing-testcontainers-python.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.7', '3.12' ]
+        python-version: [ '3.8', '3.12' ]
         cratedb-version: [ 'nightly' ]
 
     steps:


### PR DESCRIPTION
## About
Because `cratedb-sqlparse` is now part of `cratedb-toolkit`, it only supports Python 3.8 and higher now.

## Needed By
- GH-516
- GH-517
