### PR TITLE
CTK: Validate InfluxDB Table Loader

### DIFF
--- a/application/cratedb-toolkit/requirements.txt
+++ b/application/cratedb-toolkit/requirements.txt
@@ -1,1 +1,1 @@
-cratedb-toolkit[mongodb]==0.0.23
+cratedb-toolkit[influxdb,mongodb]==0.0.23


### PR DESCRIPTION
## About
Validate CTK's InfluxDB Table Loader by importing ILP data from https://github.com/influxdata/influxdb2-sample-data/tree/master/air-sensor-data.

## References
- https://github.com/daq-tools/influxio/pull/142