### PR TITLE
Table Loader: Update to CTK 0.0.29

### DIFF
--- a/application/cratedb-toolkit/requirements.txt
+++ b/application/cratedb-toolkit/requirements.txt
@@ -1,1 +1,1 @@
-cratedb-toolkit[influxdb,mongodb]==0.0.27
+cratedb-toolkit[influxdb,mongodb]==0.0.29

--- a/application/cratedb-toolkit/requirements.txt
+++ b/application/cratedb-toolkit/requirements.txt
@@ -1,1 +1,1 @@
-cratedb-toolkit[influxdb,mongodb]==0.0.24
+cratedb-toolkit[influxdb,mongodb]==0.0.27

--- a/application/cratedb-toolkit/test_io.py
+++ b/application/cratedb-toolkit/test_io.py
@@ -134,6 +134,12 @@ def test_ctk_load_table_mongodb_json(drop_testing_tables):
             progress=GitProgressPrinter(),
         )
 
+        # The `countries-big.json` file contains bogus characters.
+        countries_big_path = datasets_path / "countries-big.json"
+        payload = countries_big_path.read_text()
+        payload = payload.replace("\ufeff", "")
+        countries_big_path.write_text(payload)
+
     # Invoke data transfer.
     command = f"""
 ctk load table \

--- a/application/cratedb-toolkit/zyp-mongodb-json-files.yaml
+++ b/application/cratedb-toolkit/zyp-mongodb-json-files.yaml
@@ -38,11 +38,79 @@
 meta:
   type: zyp-project
   version: 1
+
 collections:
-- address:
-    container: datasets
-    name: companies
-  pre:
-    rules:
-    - expression: .[] |= del(.image.available_sizes, .screenshots[].available_sizes)
-      type: jq
+
+  - address:
+      container: datasets
+      name: books
+    pre:
+      rules:
+        - expression: .[] |= (._id |= tostring)
+          type: jq
+
+  - address:
+      container: datasets
+      name: city_inspections
+    pre:
+      rules:
+        - expression: |
+            .[] |= (
+              select(true)
+              | .address.number |= numbers
+              | .address.zip |= numbers
+              | .certificate_number |= tostring
+            )
+          type: jq
+
+  - address:
+      container: datasets
+      name: companies
+    pre:
+      rules:
+        - expression: |
+                .[] |= 
+                  del(
+                    .image.available_sizes,
+                    .screenshots[].available_sizes,
+                    .created_at
+                  )
+          type: jq
+
+  - address:
+      container: datasets
+      name: countries-big
+    pre:
+      rules:
+        - expression: .[] |= (.ISO |= tostring)
+          type: jq
+
+  - address:
+      container: datasets
+      name: products
+    pre:
+      rules:
+        - expression: |
+            .[] |= (
+              select(true)
+              | if (.for) then .for |= to_array end
+              | if (.type) then .type |= to_array end
+              | if (.limits.data.n) then .limits.data.n |= tostring end
+              | if (.limits.sms.n) then .limits.sms.n |= tostring end
+              | if (.limits.voice.n) then .limits.voice.n |= tostring end
+              | del(.additional_tarriffs)
+            )
+          type: jq
+
+  - address:
+      container: datasets
+      name: restaurant
+    pre:
+      rules:
+        - expression: |
+            .[] |= (
+              select(true)
+              | .rating |= tostring
+              | .type |= to_array
+            )
+          type: jq


### PR DESCRIPTION
## About
A few more transformations for importing collections from https://github.com/ozlerhakan/mongodb-json-files into CrateDB tables, after the very first variant used the Polars loader that obviously stripped away all the nested elements. 

Now, the anomalies that would otherwise make it impossible to import data into CrateDB 1:1, are handled by corresponding [jqlang expressions](https://jqlang.github.io/jq/manual/), partially just omitting offending data, but mostly converting its shape to a canonical representation.

## References
- GH-645
- GH-677

/cc @hlcianfagna, @wierdvanderhaar, @zolbatar, @kneth, @surister 