### PR TITLE
Npgsql: Adjust .NET support and version numbers on CI

### DIFF
--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         dotnet-version: [ '7.0.x', '8.0.x', '9.0.x' ]
-        npgsql-version: [ '7.0.7', '8.0.3' ]
+        npgsql-version: [ '7.0.8', '8.0.5' ]
         cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers

--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        dotnet-version: [ '7.0.x', '8.0.x' ]
+        dotnet-version: [ '7.0.x', '8.0.x', '9.0.x' ]
         npgsql-version: [ '7.0.7', '8.0.3' ]
         cratedb-version: [ 'nightly' ]
 

--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -42,8 +42,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        dotnet-version: [ '6.0.x', '7.0.x', '8.0.x' ]
-        npgsql-version: [ '6.0.11', '7.0.7', '8.0.3' ]
+        dotnet-version: [ '7.0.x', '8.0.x' ]
+        npgsql-version: [ '7.0.7', '8.0.3' ]
         cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers

--- a/by-language/csharp-npgsql/README.rst
+++ b/by-language/csharp-npgsql/README.rst
@@ -24,7 +24,7 @@ need for a plugin.
 Please note that Npgsql 5 is not supported starting with CrateDB 4.8.4, you
 will need Npgsql 6 or newer.
 
-.NET 6, 7, and 8 are supported, .NET 3.1, 4.6, and 5.0 may still work.
+.NET 7 and 8 are supported, .NET 3.1, 4.6, 5.0 and 6.0 may still work.
 
 
 *****

--- a/by-language/csharp-npgsql/README.rst
+++ b/by-language/csharp-npgsql/README.rst
@@ -24,7 +24,7 @@ need for a plugin.
 Please note that Npgsql 5 is not supported starting with CrateDB 4.8.4, you
 will need Npgsql 6 or newer.
 
-.NET 7 and 8 are supported, .NET 3.1, 4.6, 5.0 and 6.0 may still work.
+.NET 7, 8, and 9 are supported, .NET 3.1, 4.6, 5.0, and 6.0 may still work.
 
 
 *****

--- a/by-language/csharp-npgsql/demo.csproj
+++ b/by-language/csharp-npgsql/demo.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Npgsql" Version="8.0.5" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="xunit" Version="2.9.2" />


### PR DESCRIPTION
## About
- Remove support for .NET 6 and Npgsql 6.
- Add support for .NET 9.
- Update CI to use Npgsql versions 7.0.8 and 8.0.5.

## References
- GH-675