### PR TITLE
ML/LangChain: Verify examples on Python 3.13

### DIFF
--- a/.github/workflows/ml-langchain.yml
+++ b/.github/workflows/ml-langchain.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         cratedb-version: [ 'nightly' ]
 
     services:


### PR DESCRIPTION
## About
Verify if the LangChain stack (both library and examples) works well on Python 3.13 already.

## Status
It does not work, yet. pyarrow 18 will be needed.

```
Building wheel for pyarrow (pyproject.toml) did not run successfully.
```
-- https://github.com/crate/cratedb-examples/actions/runs/11512456606/job/32047504093?pr=699#step:6:853

## Progress
Edit: [pyarrow 18](https://pypi.org/project/pyarrow/18.0.0/) has been released on Oct, 28.
