### PR TITLE
ML/LlamaIndex: Use psycopg3 with SQLAlchemy instead of crate-python

### DIFF
--- a/topic/machine-learning/llama-index/env.standalone
+++ b/topic/machine-learning/llama-index/env.standalone
@@ -1,4 +1,4 @@
 # OPENAI_API_KEY=sk-XJZ7pfog5Gp8Kus8D--invalid--0CJ5lyAKSefZLaV1Y9S1
 OPENAI_API_TYPE=openai
-CRATEDB_SQLALCHEMY_URL="crate://crate@localhost:4200/"
+CRATEDB_SQLALCHEMY_URL="crate+psycopg://crate@localhost:5432/testdrive"
 CRATEDB_TABLE_NAME=time_series_data

--- a/topic/machine-learning/llama-index/main.py
+++ b/topic/machine-learning/llama-index/main.py
@@ -67,7 +67,7 @@ def main():
 
     # Configure database connection and query engine.
     print("Connecting to CrateDB")
-    engine_crate = sa.create_engine(os.getenv("CRATEDB_SQLALCHEMY_URL"))
+    engine_crate = sa.create_engine(os.getenv("CRATEDB_SQLALCHEMY_URL"), echo=True)
     engine_crate.connect()
 
     print("Creating LlamaIndex QueryEngine")

--- a/topic/machine-learning/llama-index/requirements.txt
+++ b/topic/machine-learning/llama-index/requirements.txt
@@ -4,4 +4,4 @@ llama-index-embeddings-openai<0.3
 llama-index-llms-azure-openai<0.3
 llama-index-llms-openai<0.3
 python-dotenv
-sqlalchemy-cratedb
+sqlalchemy-cratedb[all] @ git+https://github.com/crate/sqlalchemy-cratedb@amo/postgresql-async


### PR DESCRIPTION
## About
An attempt to demonstrate how to swap in the psycopg3 driver, but still use the CrateDB SQLAlchemy dialect.

## Status
Trips.
```python
sqlalchemy.exc.NoSuchTableError: time_series_data
```

## Backlog
Exception happens on table inquiry, and needs to be addressed at [sqlalchemy-cratedb] and/or [sqlalchemy-postgresql-relaxed]?

[sqlalchemy-cratedb]: https://github.com/crate/sqlalchemy-cratedb
[sqlalchemy-postgresql-relaxed]: https://github.com/pyveci/sqlalchemy-postgresql-relaxed
