### PR TITLE
Apache Superset: Update to `sqlalchemy-cratedb>=0.40.1`

### DIFF
--- a/application/apache-superset/requirements.txt
+++ b/application/apache-superset/requirements.txt
@@ -1,3 +1,2 @@
 apache-superset
-crate>=1.0.0.dev2
-sqlalchemy-cratedb>=0.36.1,<1
+sqlalchemy-cratedb>=0.40.1


### PR DESCRIPTION
## About
Validate Apache Superset with the most recent version of the CrateDB SQLAlchemy dialect.

## References
[Migrate from `crate.client`](https://cratedb.com/docs/sqlalchemy-cratedb/migrate-from-crate-client.html)
