### PR TITLE
Apache Superset: Downgrade to PyJWT 2.9

### DIFF
--- a/application/apache-superset/requirements.txt
+++ b/application/apache-superset/requirements.txt
@@ -1,2 +1,3 @@
 apache-superset
+pyjwt<2.10
 sqlalchemy-cratedb>=0.40.1


### PR DESCRIPTION
## About
Trying to fix CI for Apache Superset.
- GH-741