### PR TITLE
Apache Superset: Add version 4 to test matrix

### DIFF
--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
-        superset-version: [ "3.*" ]
+        superset-version: [ "3.*", "4.*" ]
         python-version: [ "3.9", "3.11" ]
         cratedb-version: [ 'nightly' ]
 

--- a/application/apache-superset/superset_config.py
+++ b/application/apache-superset/superset_config.py
@@ -1,3 +1,8 @@
+# Disable telemetry using Scarf.
+# https://about.scarf.sh/
+# https://github.com/apache/superset/issues/25639
+ENABLE_TELEMETRY = False
+
 # Superset specific config
 ROW_LIMIT = 5000
 

--- a/application/apache-superset/test.py
+++ b/application/apache-superset/test.py
@@ -45,7 +45,7 @@ def test_ui():
     Log in to Superset UI, navigate to SQL Lab, and exercise a query.
     """
     uri_home = "http://127.0.0.1:8088/"
-    uri_sqllab = "http://127.0.0.1:8088/superset/sqllab"
+    uri_sqllab = "http://127.0.0.1:8088/sqllab"
 
     with sync_playwright() as p:
         browser = p.firefox.launch(


### PR DESCRIPTION
## About
Apache Superset 4 was released on Apr 8, 2024.

-- https://pypi.org/project/apache-superset/#history