### PR TITLE
Java JDBC: Use explicit schema name `testdrive`

### DIFF
--- a/by-language/java-jdbc/Makefile
+++ b/by-language/java-jdbc/Makefile
@@ -1,3 +1,3 @@
 test:
-	mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://localhost:5432/'"
-	mvn exec:java -Dexec.args="--dburl 'jdbc:crate://localhost:5432/'"
+	mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://localhost:5432/testdrive'"
+	mvn exec:java -Dexec.args="--dburl 'jdbc:crate://localhost:5432/testdrive'"

--- a/by-language/java-jdbc/README.rst
+++ b/by-language/java-jdbc/README.rst
@@ -41,18 +41,18 @@ Invoke example program::
 Connect to instance on ``localhost``::
 
     # Use vanilla PostgreSQL JDBC driver.
-    mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://localhost:5432/'"
+    mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://localhost:5432/testdrive'"
 
     # Use CrateDB legacy JDBC driver.
-    mvn exec:java -Dexec.args="--dburl 'jdbc:crate://localhost:5432/'"
+    mvn exec:java -Dexec.args="--dburl 'jdbc:crate://localhost:5432/testdrive'"
 
 Connect to CrateDB Cloud::
 
     # Use vanilla PostgreSQL JDBC driver.
-    mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://example.aks1.westeurope.azure.cratedb.net:5432/' --user 'admin' --password '<PASSWORD>'"
+    mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://example.aks1.westeurope.azure.cratedb.net:5432/testdrive' --user 'admin' --password '<PASSWORD>'"
 
     # Use CrateDB legacy JDBC driver.
-    mvn exec:java -Dexec.args="--dburl 'jdbc:crate://example.aks1.westeurope.azure.cratedb.net:5432/' --user 'admin' --password '<PASSWORD>'"
+    mvn exec:java -Dexec.args="--dburl 'jdbc:crate://example.aks1.westeurope.azure.cratedb.net:5432/testdrive' --user 'admin' --password '<PASSWORD>'"
 
 In order to clean the build artefacts, invoke::
 

--- a/by-language/java-qa/src/test/java/io/crate/qa/JdbcMetaDataTest.java
+++ b/by-language/java-qa/src/test/java/io/crate/qa/JdbcMetaDataTest.java
@@ -28,7 +28,7 @@ public class JdbcMetaDataTest {
         .fromURL("https://cdn.crate.io/downloads/releases/nightly/crate-latest.tar.gz")
         .settings(Map.of("psql.port", 55432))
         .build();
-    public static final String URL = "jdbc:postgresql://localhost:55432/doc?user=crate";
+    public static final String URL = "jdbc:postgresql://localhost:55432/testdrive?user=crate";
 
     @Test
     public void test_allProceduresAreCallable() throws Exception {

--- a/by-language/java-qa/src/test/java/io/crate/qa/JdbcTest.java
+++ b/by-language/java-qa/src/test/java/io/crate/qa/JdbcTest.java
@@ -23,12 +23,12 @@ public class JdbcTest {
         .fromURL("https://cdn.crate.io/downloads/releases/nightly/crate-latest.tar.gz")
         .settings(Map.of("psql.port", 55433))
         .build();
-    public static final String URL = "jdbc:postgresql://localhost:55433/doc?user=crate";
+    public static final String URL = "jdbc:postgresql://localhost:55433/testdrive?user=crate";
 
     @After
     public void after() throws Exception {
         try (var conn = DriverManager.getConnection(URL)) {
-            var tables = conn.getMetaData().getTables(null, "doc", null, null);
+            var tables = conn.getMetaData().getTables(null, "testdrive", null, null);
             while (tables.next()) {
                 String schema = tables.getString(2);
                 String table = tables.getString(3);


### PR DESCRIPTION
Otherwise, resources would be created within the `crate` schema, which might be unfortunate for various reasons.

The intention of the micro examples is to show users best practices. While the documentation will certainly educate about the `doc` schema, I think it will be fine to use a canonical dedicated schema name for this collection of example programs?

- See also: https://github.com/crate/crate-clients-tools/pull/151