### PR TITLE
Apache Superset: Fix JWT problem by updating to flask-jwt-extended 4.7.1

### DIFF
--- a/application/apache-superset/requirements.txt
+++ b/application/apache-superset/requirements.txt
@@ -1,3 +1,3 @@
 apache-superset
-pyjwt<2.10
+flask-jwt-extended>=4.7.1
 sqlalchemy-cratedb>=0.40.1

--- a/application/apache-superset/superset_config.py
+++ b/application/apache-superset/superset_config.py
@@ -15,6 +15,12 @@ ROW_LIMIT = 5000
 # to start and you will see an error in the logs accordingly.
 SECRET_KEY = 'VcKzHS4g2h+dP33tCbqOghtKaU37wvFECMhVqrfccaoI/17qh/j3+VDV'
 
+# Configure JWT subsystem to not enforce that the sub claim is a string.
+# https://github.com/crate/cratedb-examples/issues/741
+# https://github.com/apache/superset/issues/30995
+# https://github.com/dpgaspar/Flask-AppBuilder/issues/2287
+JWT_VERIFY_SUB = False
+
 # The SQLAlchemy connection string to your database backend
 # This connection defines the path to the database that stores your
 # superset metadata (slices, connections, tables, dashboards, ...).


### PR DESCRIPTION
## About
There was a policy/constraint update in PyJWT 2.10 that broke the little test harness.
- https://github.com/jpadilla/pyjwt/issues/1017

[flask-jwt-extended 4.7.1](https://github.com/vimalloc/flask-jwt-extended/releases/tag/4.7.1) compensates for that, by also configuring `JWT_VERIFY_SUB = False`.

## References
- https://github.com/crate/cratedb-examples/issues/741
- https://github.com/apache/superset/issues/30995
- https://github.com/dpgaspar/Flask-AppBuilder/issues/2287
