### PR TITLE
Metabase: Update to v0.52.1.1-cratedb

### DIFF
--- a/application/metabase/docker-compose.yml
+++ b/application/metabase/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   # Metabase
   # https://www.metabase.com/docs/latest/installation-and-operation/running-metabase-on-docker#example-docker-compose-yaml-file
   metabase:
-    image: metabase/metabase:v0.48.3
+    image: ghcr.io/crate/metabase:v0.52.1.1-cratedb
     container_name: metabase
     hostname: metabase
     volumes:


### PR DESCRIPTION
## About
Metabase starting with v0.48.4 is no longer able to connect to CrateDB.
- https://github.com/crate/crate-clients-tools/issues/153

The CI on this PR verifies it works again, at least roughly, based on an OCI build from a version of most recent Metabase v0.52.1.1 that includes this patch, which adjusts the vanilla PostgreSQL adapter.
- https://github.com/crate/metabase/pull/38
