### PR TITLE
SQLFrame: On the "all-types" validation, use `char` instead of `character`

### DIFF
--- a/by-dataframe/sqlframe/example_types.py
+++ b/by-dataframe/sqlframe/example_types.py
@@ -49,7 +49,7 @@ RECORD_IN = dict(
     bit="01010101",
     bool=True,
     text="foobar",
-    character="foo",
+    char="foo",
     timestamp_tz="1970-01-02T00:00:00+01:00",
     timestamp_notz="1970-01-02T00:00:00",
     ip="127.0.0.1",
@@ -64,7 +64,7 @@ RECORD_IN = dict(
 RECORD_OUT = deepcopy(RECORD_IN)
 RECORD_OUT.update(
     dict(
-        character="foo  ",
+        char="foo  ",
         timestamp_tz=dt.datetime(1970, 1, 1, 23, 0, tzinfo=dt.timezone.utc),
         timestamp_notz=dt.datetime(1970, 1, 2, 0, 0, tzinfo=dt.timezone.utc),
         # FIXME: `geopoint` comes back as string, `'(85.42999997735023,66.22999997343868)'`
@@ -106,7 +106,7 @@ def sqlframe_ddl_dml_dql():
         bit BIT(8),
         bool BOOLEAN,
         text TEXT,
-        character CHARACTER(5),
+        char CHAR(5),
         timestamp_tz TIMESTAMP WITH TIME ZONE,
         timestamp_notz TIMESTAMP WITHOUT TIME ZONE,
         ip IP,


### PR DESCRIPTION
## Introduction

When submitting a record like this to CrateDB using [SQLFrame](https://github.com/eakmanrq/sqlframe),

https://github.com/crate/cratedb-examples/blob/82cb58159d3371ba2a48f374da9245faf9784e3f/by-dataframe/sqlframe/example_types.py#L41-L61

... it generates SQL statements like this:
```sql
SELECT 
  ...
  "integer" AS "integer", 
  "bigint" AS "bigint",
  "float" AS "float", 
  ...
```

## Problem

With an aliasing to `char`, changed within this patch (instead of `character`), CrateDB only trips on the `"char" AS "char"` fragment, but not on others.

```python
psycopg2.errors.InternalError_: line 1:229: no viable alternative at input
```
```sql
SELECT 
  "bool" AS "bool", 
  "text" AS "text", 
  "char" AS'
```

## Most basic reproduction
```sql
cr> select 42 as "string";
+---------+
| string |
+---------+
|      42 |
+---------+
SELECT 1 row in set (0.002 sec)
```
```sql
cr> select 42 as "char";
SQLParseException[line 1:14: no viable alternative at input 'select 42 as "char"']
```
- https://github.com/crate/crate/issues/17108

## Traceback
```java
FAILED test.py::test_ddl_dml_dql - psycopg2.errors.InternalError_: line 1:229: no viable alternative at input 'SELECT "null_integer", "integer" AS "integer", "bigint" AS "bigint", "float" AS "float", "double" AS "double", "decimal" AS "decimal", "bit" AS "bit", "bool" AS "bool", "text" AS "text", "char" AS'
CONTEXT:  io.crate.exceptions.SQLExceptions.esToCrateException(SQLExceptions.java:211)
io.crate.exceptions.SQLExceptions.prepareForClientTransmission(SQLExceptions.java:200)
io.crate.protocols.postgres.Messages.sendErrorResponse(Messages.java:195)
io.crate.protocols.postgres.Messages.sendErrorResponse(Messages.java:188)
io.crate.protocols.postgres.PostgresWireProtocol.handleSimpleQuery(PostgresWireProtocol.java:800)
io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.dispatchMessage(PostgresWireProtocol.java:341)
io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.dispatchState(PostgresWireProtocol.java:331)
io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.channelRead0(PostgresWireProtocol.java:299)
io.crate.protocols.postgres.PostgresWireProtocol$MessageHandler.channelRead0(PostgresWireProtocol.java:283)
io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99)
io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:346)
io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:318)
io.crate.protocols.postgres.PgDecoder.channelRead(PgDecoder.java:116)
io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)
io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:412)
io.netty.channel.ChannelInboundHandlerAdapter.channelRead(ChannelInboundHandlerAdapter.java:93)
```
-- https://github.com/crate/cratedb-examples/actions/runs/12234558808/job/34124004513?pr=767#step:6:193

## References
- https://github.com/crate/crate/issues/17108