### PR TITLE
Npgsql: Use `Npgsql.CrateDB` instead of vanilla `Npgsql`

### DIFF
--- a/by-language/csharp-npgsql/DemoProgram.cs
+++ b/by-language/csharp-npgsql/DemoProgram.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using CommandLine;
 using Npgsql;
+using Npgsql.CrateDb;
 using NpgsqlTypes;
 
 namespace demo
@@ -15,6 +16,11 @@ namespace demo
             await Parser.Default.ParseArguments<Options>(args)
                 .WithParsedAsync<Options>(async options =>
                 {
+
+                    // Before connecting to CrateDB, set up the plugin.
+                    // https://cratedb.com/docs/npgsql/en/latest/connect.html
+                    NpgsqlDatabaseInfo.RegisterFactory(new CrateDbDatabaseInfoFactory());
+
                     var connString = $"Host={options.Host};Port={options.Port};SSL Mode={options.SslMode};" +
                                      $"Username={options.Username};Password={options.Password};Database={options.Database}";
                     Console.WriteLine($"Connecting to {connString}\n");

--- a/by-language/csharp-npgsql/demo.csproj
+++ b/by-language/csharp-npgsql/demo.csproj
@@ -10,9 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Npgsql.CrateDB" Version="1.2.3" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />


### PR DESCRIPTION
## About
Probing better type support for Npgsql, or even trying to build it.

## Status
I don't know why `dotnet test` succeeds test runs in conditions I would expect it to fail. Anyway, on .NET 8, it just errors out like
```
    /path/to/cratedb-examples/by-language/csharp-npgsql/tests/DemoProgramTest.cs(25): error TESTERROR:
      demo.tests.DemoProgramTest.TestSystemQueryExample (1ms): Error Message: Class fixture type 'demo.tests.DatabaseFixture' threw in its constructor
      ---- Npgsql.NpgsqlException : Unknown message code: 0
```
`Npgsql.CrateDB` is outdated, as expected, and we need to investigate if it would yield a positive outcome if it would be resurrected.
