### PR TITLE
Npgsql: Use `EnableDynamicJson` to unlock better container type mappings

### DIFF
--- a/by-language/csharp-npgsql/BasicPoco.cs
+++ b/by-language/csharp-npgsql/BasicPoco.cs
@@ -1,0 +1,22 @@
+namespace demo;
+
+public class BasicPoco
+{
+
+    public string? name { get; set; }
+    public int? age { get; set; }
+
+    public override bool Equals(object obj)
+    {
+        var other = (BasicPoco) obj;
+        return name == other.name && age == other.age;
+    }
+
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
+
+    public override string ToString() => "Name: " + name + " Age: " + age;
+
+}

--- a/by-language/csharp-npgsql/DemoProgram.cs
+++ b/by-language/csharp-npgsql/DemoProgram.cs
@@ -18,12 +18,18 @@ namespace demo
                     var connString = $"Host={options.Host};Port={options.Port};SSL Mode={options.SslMode};" +
                                      $"Username={options.Username};Password={options.Password};Database={options.Database}";
                     Console.WriteLine($"Connecting to {connString}\n");
-                    await using var conn = new NpgsqlConnection(connString);
-                    conn.Open();
+
+                    var dataSourceBuilder = new NpgsqlDataSourceBuilder(connString);
+                    dataSourceBuilder.EnableDynamicJson();
+                    await using var dataSource = dataSourceBuilder.Build();
+                    await using var conn = dataSource.OpenConnection();
+
                     await DatabaseWorkloads.SystemQueryExample(conn);
                     await DatabaseWorkloads.BasicConversationExample(conn);
                     await DatabaseWorkloads.UnnestExample(conn);
-                    await DatabaseWorkloadsMore.AllTypesExample(conn);
+                    await DatabaseWorkloadsMore.AllTypesNativeExample(conn);
+                    await DatabaseWorkloadsMore.ObjectPocoExample(conn);
+                    await DatabaseWorkloadsMore.ArrayPocoExample(conn);
                     conn.Close();
                 });
 

--- a/by-language/csharp-npgsql/DemoProgram.cs
+++ b/by-language/csharp-npgsql/DemoProgram.cs
@@ -27,11 +27,13 @@ namespace demo
                     await DatabaseWorkloads.SystemQueryExample(conn);
                     await DatabaseWorkloads.BasicConversationExample(conn);
                     await DatabaseWorkloads.UnnestExample(conn);
-                    await DatabaseWorkloadsMore.AllTypesNativeExample(conn);
-                    await DatabaseWorkloadsMore.ObjectJsonDocumentExample(conn);
-                    // await DatabaseWorkloadsMore.ArrayJsonDocumentExample(conn);
-                    await DatabaseWorkloadsMore.ObjectPocoExample(conn);
-                    await DatabaseWorkloadsMore.ArrayPocoExample(conn);
+
+                    var dwt = new DatabaseWorkloadsTypes(conn);
+                    await dwt.AllTypesNativeExample();
+                    await dwt.ObjectJsonDocumentExample();
+                    // await dwt.ArrayJsonDocumentExample();
+                    await dwt.ObjectPocoExample();
+                    await dwt.ArrayPocoExample();
                     conn.Close();
                 });
 

--- a/by-language/csharp-npgsql/DemoProgram.cs
+++ b/by-language/csharp-npgsql/DemoProgram.cs
@@ -28,6 +28,8 @@ namespace demo
                     await DatabaseWorkloads.BasicConversationExample(conn);
                     await DatabaseWorkloads.UnnestExample(conn);
                     await DatabaseWorkloadsMore.AllTypesNativeExample(conn);
+                    await DatabaseWorkloadsMore.ObjectJsonDocumentExample(conn);
+                    // await DatabaseWorkloadsMore.ArrayJsonDocumentExample(conn);
                     await DatabaseWorkloadsMore.ObjectPocoExample(conn);
                     await DatabaseWorkloadsMore.ArrayPocoExample(conn);
                     conn.Close();

--- a/by-language/csharp-npgsql/README.rst
+++ b/by-language/csharp-npgsql/README.rst
@@ -21,10 +21,8 @@ data provider for PostgreSQL, `crate-npgsql`_. CrateDB versions 4.2 and later
 work with the vanilla `Npgsql - .NET Access to PostgreSQL`_ driver without the
 need for a plugin.
 
-Please note that Npgsql 5 is not supported starting with CrateDB 4.8.4, you
-will need Npgsql 6 or newer.
-
-.NET 7, 8, and 9 are supported, .NET 3.1, 4.6, 5.0, and 6.0 may still work.
+The example program in this folder is validated on .NET 8 and 9,
+using Npgsql 8.x and 9.x.
 
 
 *****
@@ -37,38 +35,41 @@ To invoke a CrateDB instance for evaluation purposes, run::
 
 Invoke example program::
 
-    dotnet run --framework=net8.0
+    dotnet run
 
 To connect to CrateDB Cloud, use a command like::
 
-    dotnet run --framework=net8.0 -- \
+    dotnet run -- \
         --host=clustername.aks1.westeurope.azure.cratedb.net --ssl-mode=Require \
         --username=foobar --password='X8F%Shn)TESTvF5ac7%eW4NM'
 
 Explore all available connection options::
 
-    dotnet run --framework=net8.0 -- --help
+    dotnet run -- --help
 
+.. note::
+
+    Use the ``--framework=net8.0`` option to target a specific .NET framework version.
 
 Tests
 =====
 
 For running the test scenarios wrapped into a xUnit test suite, invoke::
 
-    dotnet test --framework=net8.0
+    dotnet test
 
 To generate a Cobertura code coverage report, run::
 
-    dotnet test --framework=net8.0 --collect:"XPlat Code Coverage"
+    dotnet test --collect:"XPlat Code Coverage"
 
 For running the tests against a remote database, use, for example::
 
     export CRATEDB_DSN='Host=clustername.aks1.westeurope.azure.cratedb.net;Port=5432;SSL Mode=Require;Username=foobar;Password=X8F%Shn)TESTvF5ac7%eW4NM;Database=testdrive'
-    dotnet test --framework=net8.0
+    dotnet test
 
 For running tests selectively, use::
 
-    dotnet test --framework=net8.0 --filter SystemQueryExample
+    dotnet test --filter SystemQueryExample
 
 
 Troubleshooting
@@ -82,7 +83,7 @@ If you observe an error like this when invoking the program or test case::
 
 please adjust ``demo.csproj`` like that::
 
--    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+-    <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
 +    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
 
 

--- a/by-language/csharp-npgsql/tests/DemoProgramTest.cs
+++ b/by-language/csharp-npgsql/tests/DemoProgramTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Npgsql;
 using Xunit;
@@ -166,6 +167,19 @@ namespace demo.tests
                 Assert.Equal("bar", dataTable.Rows[0]["foo"]);
             }
 
+        }
+
+        [Fact]
+        public async Task TestObjectJsonDocumentExample()
+        {
+            var conn = fixture.Db;
+
+            // Invoke database workload.
+            var task = DatabaseWorkloadsMore.ObjectJsonDocumentExample(conn);
+            var obj = await task.WaitAsync(TimeSpan.FromSeconds(0.5));
+
+            // Validate the outcome.
+            Assert.Equal("""{"foo":"bar"}""", JsonSerializer.Serialize(obj));
         }
 
         [Fact]

--- a/by-language/csharp-npgsql/tests/DemoProgramTest.cs
+++ b/by-language/csharp-npgsql/tests/DemoProgramTest.cs
@@ -92,7 +92,7 @@ namespace demo.tests
             var conn = fixture.Db;
 
             // Provision data.
-            var task = DatabaseWorkloadsMore.AllTypesNativeExample(conn);
+            var task = new DatabaseWorkloadsTypes(conn).AllTypesNativeExample();
             var dt = await task.WaitAsync(TimeSpan.FromSeconds(0.5));
 
             // Check results.
@@ -146,7 +146,7 @@ namespace demo.tests
             var conn = fixture.Db;
 
             // Provision data.
-            var task = DatabaseWorkloadsMore.AllTypesNativeExample(conn);
+            var task = new DatabaseWorkloadsTypes(conn).AllTypesNativeExample();
             await task.WaitAsync(TimeSpan.FromSeconds(0.5));
 
             // Run an SQL query indexing into ARRAY types.
@@ -175,7 +175,7 @@ namespace demo.tests
             var conn = fixture.Db;
 
             // Invoke database workload.
-            var task = DatabaseWorkloadsMore.ObjectJsonDocumentExample(conn);
+            var task = new DatabaseWorkloadsTypes(conn).ObjectJsonDocumentExample();
             var obj = await task.WaitAsync(TimeSpan.FromSeconds(0.5));
 
             // Validate the outcome.
@@ -188,7 +188,7 @@ namespace demo.tests
             var conn = fixture.Db;
 
             // Invoke database workload.
-            var task = DatabaseWorkloadsMore.ObjectPocoExample(conn);
+            var task = new DatabaseWorkloadsTypes(conn).ObjectPocoExample();
             var obj = await task.WaitAsync(TimeSpan.FromSeconds(0.5));
 
             // Validate the outcome.
@@ -202,7 +202,7 @@ namespace demo.tests
             var conn = fixture.Db;
 
             // Invoke database workload.
-            var task = DatabaseWorkloadsMore.ArrayPocoExample(conn);
+            var task = new DatabaseWorkloadsTypes(conn).ArrayPocoExample();
             var obj = await task.WaitAsync(TimeSpan.FromSeconds(0.5));
 
             // Validate the outcome.


### PR DESCRIPTION
## About
This patch resolves a few FIXME admonitions introduced by a recent patch that started to validate all of CrateDB's data types with Npgsql.

- Yay: GH-772
- Not applicable: GH-776

## Details
Vanilla Npgsql provides good enough support to handle CrateDB's ARRAY and OBJECT types better than just plain strings. This patch demonstrates type mappings using three different variants:

- Native .NET `System.Collections.Generic.List` and `System.Collections.Generic.Dictionary` types.
- Native .NET `System.Text.Json.JsonDocument` type. [^1] Thanks, @simonprickett.
- Custom .NET POCO types.

## What's Inside
- Use `NpgsqlDbType.Json` explicitly where applicable, for example when communicating parameters using `AddWithValue()`.
- Use `EnableDynamicJson()` on the `NpgsqlDataSourceBuilder`, for POCO and `Dictionary` mappings that didn't work before.

## What's Next
Include relevant information into a dedicated documentation page, in order to educate readers properly in the spirit of "seeing is believing".

[^1]: Currently works with OBJECT for me, but not ARRAY.
