### PR TITLE
Npgsql: Use the latest .NET target framework available

### DIFF
--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -42,8 +42,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-22.04' ]
-        dotnet-version: [ '7.0.x', '8.0.x', '9.0.x' ]
-        npgsql-version: [ '7.0.9', '8.0.6', '9.0.2' ]
+        dotnet-version: [ '8.0.x', '9.0.x' ]
+        npgsql-version: [ '8.0.6', '9.0.2' ]
         cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers

--- a/by-language/csharp-npgsql/demo.csproj
+++ b/by-language/csharp-npgsql/demo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>


### PR DESCRIPTION
## About

Use `<TargetFramework>net$(NETCoreAppMaximumVersion)</TargetFramework>` in `.csproj` to set the target framework to the latest version available for the SDK. Thanks, @meziantou!

-- https://www.meziantou.net/how-to-use-the-latest-target-framework-available-for-a-dotnet-sdk.htm

/cc @simonprickett, @kneth 