### PR TITLE
Npgsql: Use `NpgsqlPoint` .NET type for marshalling `GEO_POINT` types. Explore communicating and marshalling GeoJSON types.

### DIFF
--- a/by-language/csharp-npgsql/DemoProgram.cs
+++ b/by-language/csharp-npgsql/DemoProgram.cs
@@ -17,12 +17,8 @@ namespace demo
                 {
                     var connString = $"Host={options.Host};Port={options.Port};SSL Mode={options.SslMode};" +
                                      $"Username={options.Username};Password={options.Password};Database={options.Database}";
-                    Console.WriteLine($"Connecting to {connString}\n");
 
-                    var dataSourceBuilder = new NpgsqlDataSourceBuilder(connString);
-                    dataSourceBuilder.EnableDynamicJson();
-                    await using var dataSource = dataSourceBuilder.Build();
-                    await using var conn = dataSource.OpenConnection();
+                    await using var conn = GetConnection(connString);
 
                     await DatabaseWorkloads.SystemQueryExample(conn);
                     await DatabaseWorkloads.BasicConversationExample(conn);
@@ -34,9 +30,32 @@ namespace demo
                     // await dwt.ArrayJsonDocumentExample();
                     await dwt.ObjectPocoExample();
                     await dwt.ArrayPocoExample();
+                    await dwt.GeoJsonTypesExample();
                     conn.Close();
                 });
 
+        }
+
+        public static NpgsqlConnection GetConnection(string connString)
+        {
+            Console.WriteLine($"Connecting to database: {connString}\n");
+
+            // Enable JSON POCO mapping and PostGIS/GeoJSON Type Plugin.
+            // https://www.npgsql.org/doc/types/json.html
+            // https://www.npgsql.org/doc/types/geojson.html
+            var dataSourceBuilder = new NpgsqlDataSourceBuilder(connString);
+
+            // Enable JSON POCO mapping Plugin.
+            // https://www.npgsql.org/doc/types/json.html
+            dataSourceBuilder.EnableDynamicJson();
+
+            // Enable PostGIS/GeoJSON Type Plugin.
+            // https://www.npgsql.org/doc/types/geojson.html
+            // dataSourceBuilder.UseGeoJson();
+
+            var dataSource = dataSourceBuilder.Build();
+            var conn = dataSource.OpenConnection();
+            return conn;
         }
 
         public class Options

--- a/by-language/csharp-npgsql/DemoTypes.cs
+++ b/by-language/csharp-npgsql/DemoTypes.cs
@@ -166,12 +166,27 @@ namespace demo
                 cmd.Parameters.AddWithValue("timestamp_tz", "1970-01-02T00:00:00+01:00");
                 cmd.Parameters.AddWithValue("timestamp_notz", "1970-01-02T00:00:00");
                 cmd.Parameters.AddWithValue("ip", "127.0.0.1");
+
+                // Container types
                 cmd.Parameters.AddWithValue("array", NpgsqlDbType.Json, new List<string>{"foo", "bar"});
                 cmd.Parameters.AddWithValue("object", NpgsqlDbType.Json, new Dictionary<string, string>{{"foo", "bar"}});
-                cmd.Parameters.AddWithValue("geopoint", new List<double>{85.43, 66.23});
-                // TODO: Check if `GEO_SHAPE` types can be represented by real .NET or Npgsql data types.
+
+                // Geospatial types
+
+                // GEO_POINT
+                // Alternatively to `NpgsqlPoint`, you can also use `List<double>{85.43, 66.23}`.
+                cmd.Parameters.AddWithValue("geopoint", new NpgsqlPoint(85.43, 66.23));
+
+                // GEO_SHAPE
+                // While `GEO_POINT` is transparently marshalled as `NpgsqlPoint`,
+                // `GEO_SHAPE` is communicated as scalar `string` type, using WKT or GeoJSON format.
+                // TODO: Possibly support transparently converging `GEO_SHAPE` to one of
+                //       `NpgsqlLSeg`, `NpgsqlBox`, `NpgsqlPath`, `NpgsqlPolygon`, `NpgsqlCircle`.
                 cmd.Parameters.AddWithValue("geoshape", "POLYGON ((5 5, 10 5, 10 10, 5 10, 5 5))");
+
+                // Vector type
                 cmd.Parameters.AddWithValue("float_vector", new List<double> {1.1, 2.2, 3.3});
+
                 cmd.ExecuteNonQuery();
             }
 

--- a/by-language/csharp-npgsql/demo.csproj
+++ b/by-language/csharp-npgsql/demo.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="GeoJSON.Net" Version="1.4.1" />
     <PackageReference Include="Npgsql" Version="9.0.2" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/by-language/csharp-npgsql/tests/DemoProgramTest.cs
+++ b/by-language/csharp-npgsql/tests/DemoProgramTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Npgsql;
+using NpgsqlTypes;
 using Xunit;
 
 namespace demo.tests
@@ -129,11 +130,11 @@ namespace demo.tests
             // Assert.Equal(new Dictionary<string, string>{{"foo", "bar"}}, row["object"]);
 
             // Geospatial types
-            // TODO: Unlock native data types?
-            //       GEO_POINT and GEO_SHAPE types can be marshalled back and forth using STRING.
-            //       GEO_POINT is using a tuple format, GEO_SHAPE is using the GeoJSON format.
-            // Assert.Equal(new List<double>{85.43, 66.23}, row["geopoint"]);  // TODO
-            Assert.Equal("(85.42999997735023,66.22999997343868)", row["geopoint"].ToString());  // FIXME
+            // While `GEO_POINT` is transparently marshalled as `NpgsqlPoint`,
+            // `GEO_SHAPE` is communicated as scalar `string` type, using the GeoJSON format.
+            // TODO: Possibly support transparently converging `GEO_SHAPE` to one of
+            //       `NpgsqlLSeg`, `NpgsqlBox`, `NpgsqlPath`, `NpgsqlPolygon`, `NpgsqlCircle`.
+            Assert.Equal(new NpgsqlPoint(85.42999997735023, 66.22999997343868), row["geopoint"]);
             Assert.Equal("""{"coordinates":[[[5.0,5.0],[5.0,10.0],[10.0,10.0],[10.0,5.0],[5.0,5.0]]],"type":"Polygon"}""", row["geoshape"]);
 
             // Vector type


### PR DESCRIPTION
## About
Explore CrateDB+Npgsql type support for geometry and geospatial types.

## Status
- `NpgsqlPoint` works well for `GEO_POINT` types. Thanks, @simonprickett.
- GeoJSON marshalling apparently needs to be done manually [^1].

[^1]: ... because `GEO_SHAPE` types are communicated as strings? I don't actually know the reason, but would like to investigate why it doesn't work fluently, optimally/optionally using the [PostGIS/GeoJSON Type Plugin](https://www.npgsql.org/doc/types/geojson.html)?
