### PR TITLE
CTK/InfluxDB: Demonstrate loading ILP data

### DIFF
--- a/application/cratedb-toolkit/requirements.txt
+++ b/application/cratedb-toolkit/requirements.txt
@@ -1,2 +1,2 @@
 crate>=1.0.0.dev2
-cratedb-toolkit[influxdb,mongodb]>=0.0.29
+cratedb-toolkit[influxdb,mongodb]>=0.0.30

--- a/application/cratedb-toolkit/test_io.py
+++ b/application/cratedb-toolkit/test_io.py
@@ -86,9 +86,9 @@ def test_ctk_load_table_influxdb_lp(drop_testing_tables):
 
     # Invoke data transfer.
     command = f"""
-influxio copy \
-    {influxdb_lp_url} \
-    "crate://localhost:4200/from-influxdb/air-sensor-data"
+    ctk load table \
+        "{influxdb_lp_url}" \
+        --cratedb-sqlalchemy-url="crate://localhost:4200/from-influxdb/air-sensor-data"
     """
     print(f"Invoking CTK: {command}", file=sys.stderr)
     subprocess.check_call(shlex.split(command))


### PR DESCRIPTION
## About
Data from InfluxDB Line Protocol format can be loaded directly into CrateDB using the CrateDB Toolkit.

## References
- https://github.com/crate/cratedb-toolkit/pull/333
- https://github.com/crate/cratedb-guide/pull/170

/cc @wierdvanderhaar, @simonprickett, @kneth 