### PR TITLE
CI: Provide Python 3.7. EOL, it was removed from recent GHA runners

### DIFF
--- a/.github/workflows/lang-python-dbapi.yml
+++ b/.github/workflows/lang-python-dbapi.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-22.04' ]
         python-version: [
           '3.7',
           '3.13',


### PR DESCRIPTION
What the title says.