### PR TITLE
Time Series: Update Datasets API (ctk 0.0.30), because location changed

### DIFF
--- a/topic/timeseries/requirements.txt
+++ b/topic/timeseries/requirements.txt
@@ -1,5 +1,5 @@
 crate>=1.0.0.dev2
-cratedb-toolkit[datasets]>=0.0.29
+cratedb-toolkit[datasets]>=0.0.30
 refinitiv-data<1.7
 pandas==2.0.*
 pycaret==3.3.2


### PR DESCRIPTION
## About
Another occasion where adjustments needed to be made after changing the location of the example datasets to be hosted at https://cdn.crate.io/downloads/datasets/cratedb-datasets/ now.