### PR TITLE
Dependencies: Update to `crate>=2.0.0.dev6`, restoring JSON marshalling

### DIFF
--- a/application/apache-superset/requirements.txt
+++ b/application/apache-superset/requirements.txt
@@ -1,3 +1,3 @@
 apache-superset
 flask-jwt-extended>=4.7.1
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2

--- a/application/cratedb-toolkit/requirements.txt
+++ b/application/cratedb-toolkit/requirements.txt
@@ -1,2 +1,2 @@
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6
 cratedb-toolkit[influxdb,mongodb]>=0.0.30

--- a/application/records/requirements.txt
+++ b/application/records/requirements.txt
@@ -1,3 +1,3 @@
 records<0.7
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2
 tablib[ods]

--- a/by-dataframe/dask/requirements.txt
+++ b/by-dataframe/dask/requirements.txt
@@ -1,7 +1,6 @@
 click<9
 colorlog<7
-crate>=2.0.0.dev5
 dask[dataframe]>=2024.4.1   # Python 3.11.9 breaks previous Dask
 distributed>=2024.4.1       # Python 3.11.9 breaks previous Dask
 pueblo>=0.0.10
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2

--- a/by-dataframe/pandas/requirements.txt
+++ b/by-dataframe/pandas/requirements.txt
@@ -1,6 +1,6 @@
 click<9
 colorlog<7
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6
 pandas==2.2.*
 pueblo>=0.0.10
 sqlalchemy-cratedb[all] @ git+https://github.com/crate-workbench/sqlalchemy-cratedb@amo/postgresql-async

--- a/by-language/python-dbapi/requirements.txt
+++ b/by-language/python-dbapi/requirements.txt
@@ -1,1 +1,1 @@
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6

--- a/by-language/python-sqlalchemy/requirements.txt
+++ b/by-language/python-sqlalchemy/requirements.txt
@@ -1,6 +1,6 @@
 click<9
 colorlog<7
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6
 pueblo>=0.0.7
 sqlalchemy>=2,<2.1
 sqlalchemy-cratedb[all] @ git+https://github.com/crate-workbench/sqlalchemy-cratedb@amo/postgresql-async

--- a/framework/flink/kafka-jdbcsink-python/requirements.txt
+++ b/framework/flink/kafka-jdbcsink-python/requirements.txt
@@ -5,7 +5,7 @@ avro-python3==1.10.2
 certifi==2024.2.2
 charset-normalizer==3.3.2
 cloudpickle==2.2.1
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6
 crcmod==1.7
 dill==0.3.1.1
 dnspython==2.6.1

--- a/framework/gradio/requirements.txt
+++ b/framework/gradio/requirements.txt
@@ -1,2 +1,2 @@
 gradio==4.*
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2

--- a/framework/records/requirements.txt
+++ b/framework/records/requirements.txt
@@ -1,3 +1,3 @@
 records<0.7
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2
 tablib[pandas]

--- a/framework/streamlit/requirements.txt
+++ b/framework/streamlit/requirements.txt
@@ -1,2 +1,2 @@
 streamlit==1.*
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2

--- a/testing/native/python-pytest/requirements.txt
+++ b/testing/native/python-pytest/requirements.txt
@@ -1,4 +1,4 @@
 crash>=0.31.5
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6
 pytest<9
 pytest-cratedb>=0.4.0

--- a/testing/native/python-unittest/requirements.txt
+++ b/testing/native/python-unittest/requirements.txt
@@ -1,3 +1,3 @@
 cr8>=0.27.2
 crash>=0.31.5
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6

--- a/testing/testcontainers/python-pytest/requirements.txt
+++ b/testing/testcontainers/python-pytest/requirements.txt
@@ -1,4 +1,4 @@
 crash>=0.31.5
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6
 cratedb-toolkit[testing]>=0.0.29
 pytest<9

--- a/testing/testcontainers/python-unittest/requirements.txt
+++ b/testing/testcontainers/python-unittest/requirements.txt
@@ -1,3 +1,3 @@
 crash>=0.31.5
-crate>=2.0.0.dev5
+crate>=2.0.0.dev6
 cratedb-toolkit[testing]>=0.0.29

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -1,4 +1,5 @@
 # Real.
+dask==2024.12.1
 mlflow-cratedb==2.14.1
 plotly<5.25
 pycaret[models,parallel,test]==3.3.2

--- a/topic/machine-learning/automl/requirements.txt
+++ b/topic/machine-learning/automl/requirements.txt
@@ -1,12 +1,11 @@
 # Real.
-crate>=2.0.0.dev5
 mlflow-cratedb==2.14.1
 plotly<5.25
 pycaret[models,parallel,test]==3.3.2
 pydantic<3
 python-dotenv<2
 sqlalchemy==2.*
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2
 
 # Development.
 # mlflow-cratedb @ git+https://github.com/crate-workbench/mlflow-cratedb.git@main

--- a/topic/timeseries/requirements.txt
+++ b/topic/timeseries/requirements.txt
@@ -1,8 +1,7 @@
-crate>=2.0.0.dev5
 cratedb-toolkit[datasets]>=0.0.30
 refinitiv-data<1.7
 pandas==2.0.*
 pycaret==3.3.2
 pydantic<3
 sqlalchemy==2.0.*
-sqlalchemy-cratedb>=0.41.0.dev1
+sqlalchemy-cratedb>=0.41.0.dev2


### PR DESCRIPTION
## About
The fundamental patch GH-811 needs a little update, pulling in a more recent pre-release version of crate-python.

## References
- https://github.com/crate/crate-python/pull/691