### PR TITLE
Npgsql: Remove testing on .NET 8.x

### DIFF
--- a/.github/workflows/lang-npgsql.yml
+++ b/.github/workflows/lang-npgsql.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-22.04' ]
-        dotnet-version: [ '8.0.x', '9.0.x' ]
+        dotnet-version: [ '9.0.x' ]
         npgsql-version: [ '8.0.6', '9.0.2' ]
         cratedb-version: [ 'nightly' ]
 


### PR DESCRIPTION
## About
Remove testing on .NET 8.x, as it stopped working on CI/GHA two weeks ago. Is it legit?

## Details
Error: /usr/share/dotnet/sdk/9.0.102/Sdks/Microsoft.NET.Sdk/targets/Microsoft.PackageDependencyResolution.targets(266,5):

error NETSDK1005: Assets file '/home/runner/work/cratedb-examples/cratedb-examples/by-language/csharp-npgsql/obj/project.assets.json' doesn't have a target for 'net8.0'. Ensure that restore has run and that you have included 'net8.0' in the TargetFrameworks for your project. [/home/runner/work/cratedb-examples/cratedb-examples/by-language/csharp-npgsql/demo.csproj]

- https://github.com/crate/cratedb-examples/actions/runs/13044843111/job/36393610035#step:7:77
