### PR TITLE
Rust: Add minimal example

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,6 +83,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - directory: "/by-language/rust"
+    package-ecosystem: "cargo"
+    schedule:
+      interval: "daily"
+
   # Applications.
 
   - directory: "/application/apache-superset"

--- a/.github/workflows/lang-rust-postgres.yml
+++ b/.github/workflows/lang-rust-postgres.yml
@@ -1,0 +1,61 @@
+name: Rust Postgres
+
+on:
+  pull_request:
+    paths:
+    - '.github/workflows/lang-rust-postgres.yml'
+    - 'by-language/rust-postgres/**'
+    - '/requirements.txt'
+  push:
+    branches: [ main ]
+    paths:
+    - '.github/workflows/lang-rust-postgres.yml'
+    - 'by-language/rust-postgres/**'
+    - '/requirements.txt'
+
+  # Allow job to be triggered manually.
+  workflow_dispatch:
+
+  # Run job each night after CrateDB nightly has been published.
+  schedule:
+    - cron: '0 3 * * *'
+
+# Cancel in-progress jobs when pushing to the same branch.
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+
+  test:
+    name: "
+     CrateDB: ${{ matrix.cratedb-version }}
+     on ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ 'ubuntu-latest' ]
+        cratedb-version: [ 'nightly' ]
+
+    services:
+      cratedb:
+        image: crate/crate:${{ matrix.cratedb-version }}
+        ports:
+          - 4200:4200
+          - 5432:5432
+        env:
+          CRATE_HEAP_SIZE: 4g
+
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
+      - name: Install utilities
+        run: |
+          pip install -r requirements.txt
+
+      - name: Validate by-language/rust-postgres
+        run: |
+          ngr test by-language/rust-postgres

--- a/by-language/rust-postgres/.gitignore
+++ b/by-language/rust-postgres/.gitignore
@@ -1,0 +1,2 @@
+target
+*.lock

--- a/by-language/rust-postgres/Cargo.toml
+++ b/by-language/rust-postgres/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cratedb-rust-tests"
+version = "0.0.0"
+authors = ["The CrateDB Developers"]
+edition = "2021"
+
+[dependencies]
+postgres = "0.19.7"

--- a/by-language/rust-postgres/README.md
+++ b/by-language/rust-postgres/README.md
@@ -1,0 +1,27 @@
+# Connecting to CrateDB with Rust
+
+## About
+
+The file `src/main.rs` includes a basic example program that uses the Rust
+[postgres] package, a native, synchronous PostgreSQL client, to connect to
+CrateDB.
+
+## Usage
+
+Start a CrateDB instance for evaluation purposes.
+```shell
+docker run -it --rm --publish=4200:4200 --publish=5432:5432 crate:latest
+```
+
+Invoke example program.
+```shell
+cargo run
+```
+
+Invoke software tests.
+```shell
+cargo test
+```
+
+
+[postgres]: https://crates.io/crates/postgres

--- a/by-language/rust-postgres/src/main.rs
+++ b/by-language/rust-postgres/src/main.rs
@@ -1,0 +1,59 @@
+use postgres::{Client, NoTls};
+use std::env;
+
+mod tests;
+
+pub fn main() {
+
+    // Read port number from command-line arguments.
+    // Use port 5432 by default.
+    let mut args: Vec<String> = env::args().collect();
+    if args.len() == 1 {
+        args.push("5432".to_string());
+    }
+
+    // Connect to database.
+    let mut client = Client::connect(format!("host=localhost port={} user=crate", &args[1]).as_str(), NoTls).unwrap();
+
+    // Submit DDL.
+    client
+        .simple_query("DROP TABLE IF EXISTS testdrive.rust;")
+        .unwrap();
+    client
+        .simple_query("CREATE TABLE testdrive.rust (id int primary key, x int not null, name text not null);")
+        .unwrap();
+
+    // Submit basic INSERT statement.
+    client
+        .execute(
+            "INSERT INTO testdrive.rust (id, x, name) VALUES (1, 10, 'Arthur')",
+            &[],
+        )
+        .unwrap();
+
+    // Submit prepared INSERT statement.
+    let stmt = match client
+        .prepare("INSERT INTO testdrive.rust (id, x, name) values ($1, $2, $3)") {
+            Ok(stmt) => stmt,
+            Err(e) => {
+                println!("Preparing insert failed: {:?}", e);
+                return;
+            }
+        };
+    let id = 2;
+    let x = 20;
+    let name = "Trillian";
+    client.execute(&stmt, &[&id, &x, &name]).unwrap();
+
+    // Synchronize writes.
+    client.execute("REFRESH TABLE testdrive.rust", &[]).unwrap();
+
+    // Query records.
+    for row in client.query("SELECT id, x, name FROM testdrive.rust", &[]).unwrap() {
+        let id: i32 = row.get("id");
+        let x: i32 = row.get("x");
+        let name: &str = row.get("name");
+        println!("id={} x={} name={}", &id, &x, &name);
+        assert!(id == 1 || id == 2, "id = {} but should be 1 or 2", id);
+    }
+}

--- a/by-language/rust-postgres/src/tests.rs
+++ b/by-language/rust-postgres/src/tests.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    use crate::main;
+    #[test]
+    fn test_main() {
+        main();
+    }
+}


### PR DESCRIPTION
## About

Add minimal Rust example from [crate-qa](https://github.com/crate/crate-qa/tree/master/tests/client_tests/rust) to make a start, adding a miniature rig for further explorations.

/cc @kneth 