### PR TITLE
Kafka/Flink: Update to cratedb-flink-jobs-0.6

### DIFF
--- a/framework/flink/kafka-jdbcsink-java/.env
+++ b/framework/flink/kafka-jdbcsink-java/.env
@@ -31,6 +31,6 @@ CRATEDB_HTTP_URL="${CRATEDB_HTTP_SCHEME}://${CRATEDB_USERNAME}:${CRATEDB_PASSWOR
 
 # Options for acquiring the Flink job JAR file.
 # https://github.com/crate/cratedb-flink-jobs
-FLINK_JOB_JAR_VERSION=0.5
+FLINK_JOB_JAR_VERSION=0.6
 FLINK_JOB_JAR_FILE=cratedb-flink-jobs-${FLINK_JOB_JAR_VERSION}.jar
 FLINK_JOB_JAR_URL=https://github.com/crate/cratedb-flink-jobs/releases/download/${FLINK_JOB_JAR_VERSION}/${FLINK_JOB_JAR_FILE}


### PR DESCRIPTION
## About

Accompany software testing with a new release [cratedb-flink-jobs-0.6](https://github.com/crate/cratedb-flink-jobs/releases/tag/0.6), as suggested.
The patch is stacked on top of GH-858.

## Status 🚧 

Currently, CI just sloppily says [cat: write error: Broken pipe](https://github.com/crate/cratedb-examples/actions/runs/14002771593/job/39212185159?pr=859#step:3:6007). 👊 

## References

- GH-833
- GH-858
