### PR TITLE
CI: Fix Dependabot configuration, a few paths were wrong

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -88,7 +88,7 @@ updates:
     schedule:
       interval: "daily"
 
-  - directory: "/by-language/rust"
+  - directory: "/by-language/rust-postgres"
     package-ecosystem: "cargo"
     schedule:
       interval: "daily"
@@ -111,7 +111,7 @@ updates:
       interval: "daily"
 
   - directory: "/application/metabase"
-    package-ecosystem: "docker"
+    package-ecosystem: "docker-compose"
     schedule:
       interval: "daily"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -132,6 +132,11 @@ updates:
     schedule:
       interval: "daily"
 
+  - directory: "/framework/flink/kafka-jdbcsink-java"
+    package-ecosystem: "docker-compose"
+    schedule:
+      interval: "daily"
+
   - directory: "/framework/gradio"
     package-ecosystem: "pip"
     schedule:


### PR DESCRIPTION
## Problem

On the [Dependabot job overview page](https://github.com/crate/cratedb-examples/network/updates), we discovered a few jobs that failed.
