### PR TITLE
MCP: Employ version pinning for MCP server components

### DIFF
--- a/framework/mcp/example_builtin.py
+++ b/framework/mcp/example_builtin.py
@@ -14,7 +14,7 @@ server_params = StdioServerParameters(
     command="npx",
     args=[
         "-y",
-        "@modelcontextprotocol/server-postgres",
+        "@modelcontextprotocol/server-postgres@0.6",
         "postgresql://crate@localhost:5432/doc",
     ],
     env=None,

--- a/framework/mcp/example_dbhub.py
+++ b/framework/mcp/example_dbhub.py
@@ -14,7 +14,7 @@ server_params_npx = StdioServerParameters(
     command="npx",
     args=[
         "-y",
-        "@bytebase/dbhub",
+        "@bytebase/dbhub@0.1",
         "--transport=stdio",
         #"--transport=sse",
         #"--port=8080",

--- a/framework/mcp/test.py
+++ b/framework/mcp/test.py
@@ -21,7 +21,7 @@ class Process:
         return self.proc.returncode
 
 
-def run(command: str, timeout: int = 30) -> Process:
+def run(command: str, timeout: int = 60) -> Process:
     """
     Invoke a command in a subprocess.
     """


### PR DESCRIPTION
## Problem

A recent update to [@bytebase/dbhub](https://www.npmjs.com/package/@bytebase/dbhub) made our [integration tests go south](https://github.com/crate/cratedb-examples/actions/workflows/framework-mcp.yml), because we didn't employ any version pinning there up until now.

## References

- https://github.com/quarkiverse/quarkus-mcp-servers/issues/30
