### PR TITLE
MCP: Use `cratedb-mcp@main`

### DIFF
--- a/framework/mcp/requirements.txt
+++ b/framework/mcp/requirements.txt
@@ -1,4 +1,4 @@
-cratedb-mcp @ git+https://github.com/crate/cratedb-mcp@packaging-adjustments
+cratedb-mcp @ git+https://github.com/crate/cratedb-mcp@main
 cratedb-toolkit
 mcp<1.7
 mcp-alchemy~=2025.4


### PR DESCRIPTION
Accompanying recent adjustments to the package setup of `cratedb-mcp`.

- https://github.com/crate/cratedb-mcp/pull/3