### PR TITLE
Dependencies: Update to cratedb-toolkit 0.0.33

### DIFF
--- a/application/cratedb-toolkit/requirements.txt
+++ b/application/cratedb-toolkit/requirements.txt
@@ -1,2 +1,2 @@
 crate>=2.0.0.dev6
-cratedb-toolkit[influxdb,mongodb]>=0.0.30
+cratedb-toolkit[influxdb,mongodb]>=0.0.33

--- a/application/cratedb-toolkit/test_io.py
+++ b/application/cratedb-toolkit/test_io.py
@@ -88,7 +88,7 @@ def test_ctk_load_table_influxdb_lp(drop_testing_tables):
     command = f"""
     ctk load table \
         "{influxdb_lp_url}" \
-        --cratedb-sqlalchemy-url="crate://localhost:4200/from-influxdb/air-sensor-data"
+        --cluster-url="crate://localhost:4200/from-influxdb/air-sensor-data"
     """
     print(f"Invoking CTK: {command}", file=sys.stderr)
     subprocess.check_call(shlex.split(command))
@@ -144,7 +144,7 @@ def test_ctk_load_table_mongodb_json(drop_testing_tables):
     command = f"""
 ctk load table \
     "file+bson://{datasets_path}/*.json?batch-size=2500" \
-    --cratedb-sqlalchemy-url="crate://localhost:4200/from-mongodb" \
+    --cluster-url="crate://localhost:4200/from-mongodb" \
     --transformation=zyp-mongodb-json-files.yaml
 """
     print(f"Invoking CTK: {command}", file=sys.stderr)

--- a/framework/mcp/README.md
+++ b/framework/mcp/README.md
@@ -123,7 +123,7 @@ which is applicable for all sorts of driver, adapter, and connector explorations
 After providing authentication information, just use uv's `uvx` launcher to invoke
 CrateDB Toolkit's tail command without installation.
 ```shell
-export CRATEDB_SQLALCHEMY_URL=crate://crate@localhost:4200/
+export CRATEDB_CLUSTER_URL=crate://crate@localhost:4200/
 ```
 ```shell
 uvx --from=cratedb-toolkit ctk tail -n 3 --follow --format=log-pretty sys.jobs_log

--- a/framework/mcp/requirements.txt
+++ b/framework/mcp/requirements.txt
@@ -1,5 +1,5 @@
 cratedb-mcp @ git+https://github.com/crate/cratedb-mcp@main
-cratedb-toolkit
+cratedb-toolkit>=0.0.33
 mcp<1.7
 mcp-alchemy~=2025.4
 sqlalchemy-cratedb>=0.42.0.dev2

--- a/testing/testcontainers/python-pytest/requirements.txt
+++ b/testing/testcontainers/python-pytest/requirements.txt
@@ -1,4 +1,4 @@
 crash>=0.31.5
 crate>=2.0.0.dev6
-cratedb-toolkit[testing]>=0.0.29
+cratedb-toolkit[testing]>=0.0.33
 pytest<9

--- a/testing/testcontainers/python-unittest/requirements.txt
+++ b/testing/testcontainers/python-unittest/requirements.txt
@@ -1,3 +1,3 @@
 crash>=0.31.5
 crate>=2.0.0.dev6
-cratedb-toolkit[testing]>=0.0.29
+cratedb-toolkit[testing]>=0.0.33

--- a/topic/machine-learning/automl/requirements-dev.txt
+++ b/topic/machine-learning/automl/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Real.
-cratedb-toolkit[io]>=0.0.29
+cratedb-toolkit[io]>=0.0.33
 pueblo[notebook,testing]>=0.0.10
 
 # Development.

--- a/topic/machine-learning/llama-index/requirements-dev.txt
+++ b/topic/machine-learning/llama-index/requirements-dev.txt
@@ -1,3 +1,3 @@
-cratedb-toolkit
+cratedb-toolkit>=0.0.33
 pueblo[testing]
 sqlparse

--- a/topic/machine-learning/llm-langchain/requirements-dev.txt
+++ b/topic/machine-learning/llm-langchain/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Production.
-cratedb-toolkit[io]
+cratedb-toolkit[io]>=0.0.33
 pueblo[notebook,testing]
 
 # Staging.

--- a/topic/machine-learning/mlops-mlflow/requirements-dev.txt
+++ b/topic/machine-learning/mlops-mlflow/requirements-dev.txt
@@ -1,5 +1,5 @@
 # Real.
-cratedb-toolkit[io]>=0.0.29
+cratedb-toolkit[io]>=0.0.33
 pueblo[notebook,testing]>=0.0.10
 
 # Development.

--- a/topic/timeseries/requirements.txt
+++ b/topic/timeseries/requirements.txt
@@ -1,4 +1,4 @@
-cratedb-toolkit[datasets]>=0.0.30
+cratedb-toolkit[datasets]>=0.0.33
 refinitiv-data<1.7
 pandas==2.0.*
 pycaret==3.3.2


### PR DESCRIPTION
Renamed CLI option `--cratedb-sqlalchemy-url` to `--cluster-url`
and environment variable `CRATEDB_SQLALCHEMY_URL` to `CRATEDB_CLUSTER_URL`.