### PR TITLE
Add example of GraphQL against CrateDB using Graphene

### DIFF
--- a/topic/graphql/README.md
+++ b/topic/graphql/README.md
@@ -14,7 +14,16 @@ The project contains two models, one named `Department` and another named
 
 ## Getting started
 
-First you'll need to get the source of the project. Do this by cloning the whole
+First, it is good idea (but not required) to create a virtual environment for
+this project. We'll do this using
+[venv](https://docs.python.org/3/library/venv.html) to keep things simple:
+
+```bash
+python -m venv ./graphql-demo
+source ./graphql-demo/bin/activate
+```
+
+Now we will need to get the source of the project. Do this by cloning the whole
 cratedb-examples repository:
 
 ```bash
@@ -23,19 +32,10 @@ git clone https://github.com/crate/cratedb-examples.git
 cd cratedb-examples/topic/graphql
 ```
 
-It is good idea (but not required) to create a virtual environment for this
-project. We'll do this using [venv](https://docs.python.org/3/library/venv.html)
-to keep things simple:
-
-```bash
-python -m venv ./graphql-demo
-source ./graphql-demo/bin/activate
-```
-
 Now we can install our dependencies:
 
 ```bash
-pip install -r requirements.txt
+pip install sqlalchemy-cratedb graphene_sqlalchemy Flask Flask-GraphQL
 ```
 
 Now the following command will setup the database, and start the server:

--- a/topic/graphql/README.md
+++ b/topic/graphql/README.md
@@ -41,7 +41,7 @@ pip install sqlalchemy-cratedb graphene_sqlalchemy Flask Flask-GraphQL
 Now the following command will setup the database, and start the server:
 
 ```bash
-./app.py
+python ./app.py
 
 ```
 

--- a/topic/graphql/README.md
+++ b/topic/graphql/README.md
@@ -1,0 +1,50 @@
+# Example Flask Graphene-SQLAlchemy project showing GraphQL against CrateDB
+
+This example project derived from the
+[graphene-sqlalchemy flask_sqlalchemy example](https://github.com/graphql-python/graphene-sqlalchemy/tree/master/examples/flask_sqlalchemy)
+demos how GraphQL queries can be run against data stored in CrateDB using
+Graphene-SQLAlchemy. This way the data is accessible both via SQL and GraphQL.
+
+To run this example you will need an instance of CrateDB. You can get an
+instance of
+[CrateDB running locally with docker](https://cratedb.com/docs/guide/install/container/index.html#install-container)
+
+The project contains two models, one named `Department` and another named
+`Employee`.
+
+## Getting started
+
+First you'll need to get the source of the project. Do this by cloning the whole
+cratedb-examples repository:
+
+```bash
+# Get the example project code
+git clone https://github.com/crate/cratedb-examples.git
+cd cratedb-examples/topic/graphql
+```
+
+It is good idea (but not required) to create a virtual environment for this
+project. We'll do this using [venv](https://docs.python.org/3/library/venv.html)
+to keep things simple:
+
+```bash
+python -m venv ./graphql-demo
+source ./graphql-demo/bin/activate
+```
+
+Now we can install our dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Now the following command will setup the database, and start the server:
+
+```bash
+./app.py
+
+```
+
+Now head on over to
+[http://127.0.0.1:5000/graphql](http://127.0.0.1:5000/graphql) and run some
+GraphQL queries!

--- a/topic/graphql/README.md
+++ b/topic/graphql/README.md
@@ -47,4 +47,25 @@ python ./app.py
 
 Now head on over to
 [http://127.0.0.1:5000/graphql](http://127.0.0.1:5000/graphql) and run some
-GraphQL queries!
+GraphQL queries, for example:
+
+```graphql
+{
+  allEmployees(sort: [NAME_ASC, ID_ASC]) {
+    edges {
+      node {
+        id
+        name
+        department {
+          id
+          name
+        }
+        role {
+          id
+          name
+        }
+      }
+    }
+  }
+}
+```

--- a/topic/graphql/app.py
+++ b/topic/graphql/app.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+from flask import Flask
+from flask_graphql import GraphQLView
+
+from database import db_session, init_db
+from schema import schema
+
+app = Flask(__name__)
+app.debug = True
+
+example_query = """
+{
+  allEmployees(sort: [NAME_ASC, ID_ASC]) {
+    edges {
+      node {
+        id
+        name
+        department {
+          id
+          name
+        }
+        role {
+          id
+          name
+        }
+      }
+    }
+  }
+}
+"""
+
+
+app.add_url_rule(
+    "/graphql", view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True)
+)
+
+
+@app.teardown_appcontext
+def shutdown_session(exception=None):
+    db_session.remove()
+
+
+if __name__ == "__main__":
+    init_db()
+    app.run()

--- a/topic/graphql/database.py
+++ b/topic/graphql/database.py
@@ -1,0 +1,39 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+engine = create_engine("crate://localhost:4200")
+db_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=engine)
+)
+Base = declarative_base()
+Base.query = db_session.query_property()
+
+
+def init_db():
+    # import all modules here that might define models so that
+    # they will be registered properly on the metadata.  Otherwise
+    # you will have to import them first before calling init_db()
+    from models import Department, Employee, Role
+
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    # Create the fixtures
+    engineering = Department(name="Engineering")
+    db_session.add(engineering)
+    hr = Department(name="Human Resources")
+    db_session.add(hr)
+
+    manager = Role(name="manager")
+    db_session.add(manager)
+    engineer = Role(name="engineer")
+    db_session.add(engineer)
+
+    peter = Employee(name="Peter", department=engineering, role=engineer)
+    db_session.add(peter)
+    roy = Employee(name="Roy", department=engineering, role=engineer)
+    db_session.add(roy)
+    tracy = Employee(name="Tracy", department=hr, role=manager)
+    db_session.add(tracy)
+    db_session.commit()

--- a/topic/graphql/models.py
+++ b/topic/graphql/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy import Column, DateTime, ForeignKey, BigInteger, String, func
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy_cratedb.support import patch_autoincrement_timestamp
 

--- a/topic/graphql/models.py
+++ b/topic/graphql/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, ForeignKey, BigInteger, String, func
+from sqlalchemy import Column, DateTime, ForeignKey, BigInteger, Integer, String, func
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy_cratedb.support import patch_autoincrement_timestamp
 

--- a/topic/graphql/models.py
+++ b/topic/graphql/models.py
@@ -1,0 +1,38 @@
+from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
+from sqlalchemy.orm import backref, relationship
+from sqlalchemy_cratedb.support import patch_autoincrement_timestamp
+
+from database import Base
+
+patch_autoincrement_timestamp()
+
+
+class Department(Base):
+    __tablename__ = "department"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    name = Column(String)
+
+
+class Role(Base):
+    __tablename__ = "roles"
+    role_id = Column(Integer, primary_key=True)
+    name = Column(String)
+
+
+class Employee(Base):
+    __tablename__ = "employee"
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    name = Column(String)
+    # Use default=func.now() to set the default hiring time
+    # of an Employee to be the current time when an
+    # Employee record was created
+    hired_on = Column(DateTime, default=func.now())
+    department_id = Column(BigInteger, ForeignKey("department.id"))
+    role_id = Column(Integer, ForeignKey("roles.role_id"))
+    # Use cascade='delete,all' to propagate the deletion of a Department onto its Employees
+    department = relationship(
+        Department, backref=backref("employees", uselist=True, cascade="delete,all")
+    )
+    role = relationship(
+        Role, backref=backref("roles", uselist=True, cascade="delete,all")
+    )

--- a/topic/graphql/models.py
+++ b/topic/graphql/models.py
@@ -28,7 +28,7 @@ class Employee(Base):
     # Employee record was created
     hired_on = Column(DateTime, default=func.now())
     department_id = Column(BigInteger, ForeignKey("department.id"))
-    role_id = Column(Integer, ForeignKey("roles.role_id"))
+    role_id = Column(BigInteger, ForeignKey("roles.role_id"))
     # Use cascade='delete,all' to propagate the deletion of a Department onto its Employees
     department = relationship(
         Department, backref=backref("employees", uselist=True, cascade="delete,all")

--- a/topic/graphql/models.py
+++ b/topic/graphql/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, DateTime, ForeignKey, BigInteger, Integer, String, func
+from sqlalchemy import Column, DateTime, ForeignKey, BigInteger, String, func
 from sqlalchemy.orm import backref, relationship
 from sqlalchemy_cratedb.support import patch_autoincrement_timestamp
 
@@ -15,7 +15,7 @@ class Department(Base):
 
 class Role(Base):
     __tablename__ = "roles"
-    role_id = Column(Integer, primary_key=True)
+    role_id = Column(BigInteger, primary_key=True, autoincrement=True)
     name = Column(String)
 
 

--- a/topic/graphql/requirements.txt
+++ b/topic/graphql/requirements.txt
@@ -1,0 +1,5 @@
+SQLAlchemy
+graphene_sqlalchemy
+Flask
+Flask-GraphQL
+sqlalchemy-cratedb

--- a/topic/graphql/requirements.txt
+++ b/topic/graphql/requirements.txt
@@ -1,5 +1,0 @@
-SQLAlchemy
-graphene_sqlalchemy
-Flask
-Flask-GraphQL
-sqlalchemy-cratedb

--- a/topic/graphql/schema.py
+++ b/topic/graphql/schema.py
@@ -1,0 +1,40 @@
+import graphene
+from graphene import relay
+from graphene_sqlalchemy import SQLAlchemyConnectionField, SQLAlchemyObjectType
+
+from models import Department as DepartmentModel
+from models import Employee as EmployeeModel
+from models import Role as RoleModel
+
+
+class Department(SQLAlchemyObjectType):
+    class Meta:
+        model = DepartmentModel
+        interfaces = (relay.Node,)
+
+
+class Employee(SQLAlchemyObjectType):
+    class Meta:
+        model = EmployeeModel
+        interfaces = (relay.Node,)
+
+
+class Role(SQLAlchemyObjectType):
+    class Meta:
+        model = RoleModel
+        interfaces = (relay.Node,)
+
+
+class Query(graphene.ObjectType):
+    node = relay.Node.Field()
+    # Allow only single column sorting
+    all_employees = SQLAlchemyConnectionField(
+        Employee.connection, sort=Employee.sort_argument()
+    )
+    # Allows sorting over multiple columns, by default over the primary key
+    all_roles = SQLAlchemyConnectionField(Role.connection)
+    # Disable sorting over this field
+    all_departments = SQLAlchemyConnectionField(Department.connection, sort=None)
+
+
+schema = graphene.Schema(query=Query)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This PR adds an example derived from the
[graphene-sqlalchemy flask_sqlalchemy example](https://github.com/graphql-python/graphene-sqlalchemy/tree/master/examples/flask_sqlalchemy)
demoing how GraphQL queries can be run against data stored in CrateDB using
Graphene-SQLAlchemy. This way the data is accessible both via SQL and GraphQL.

## Checklist

 - [X] Link to issue this PR refers to: Fixes https://github.com/crate/crate-clients-tools/discussions/260
