### PR TITLE
MCP/DBHub: Update to 0.11.6

### DIFF
--- a/framework/mcp/example_dbhub.py
+++ b/framework/mcp/example_dbhub.py
@@ -38,8 +38,7 @@ async def run():
             print()
 
             # Call a few tools.
-            await client.call_tool("run_query", arguments={"query": "SELECT * FROM sys.summits ORDER BY height DESC LIMIT 3"})
-            await client.call_tool("list_connectors", arguments={})
+            await client.call_tool("execute_sql", arguments={"sql": "SELECT * FROM sys.summits ORDER BY height DESC LIMIT 3"})
 
             # Validate database content.
             db = DatabaseAdapter("crate://crate@localhost:4200/")

--- a/framework/mcp/test.py
+++ b/framework/mcp/test.py
@@ -103,11 +103,8 @@ def test_dbhub():
     assert b"Universal Database MCP Server" in p.stderr
 
     # Validate output specific to CrateDB.
-    assert b"Calling tool: run_query" in p.stdout
+    assert b"Calling tool: execute_sql" in p.stdout
     assert b"mountain: Mont Blanc" in p.stdout
-
-    assert b"Calling tool: list_connectors" in p.stdout
-    assert b"dsn: postgres://postgres" in p.stdout
 
     assert b"Reading resource: db://schemas" in p.stdout
     assert b"- doc" in p.stdout


### PR DESCRIPTION
When integration testing against [DBHub](https://www.npmjs.com/package/@bytebase/dbhub)...

- ... the previous variant stopped working on Node.js 25?
- ... applying a maintenance cycle is applicable anyway, because some function signatures changed.