### PR TITLE
Python/SQLAlchemy: Fix multirow/batched exercise

### DIFF
--- a/by-language/python-sqlalchemy/insert_efficient.py
+++ b/by-language/python-sqlalchemy/insert_efficient.py
@@ -130,10 +130,13 @@ def run_database(database: str, variant: str, record_count: int):
 
 
 if __name__ == "__main__":
+    """
+    Invocation examples:
+
+    python insert_efficient.py cratedb multirow 25000
+    python insert_efficient.py cratedb batched 50000
+    """
     database = sys.argv[1]
     variant = sys.argv[2]
-    try:
-        record_count = int(sys.argv[3])
-    except:
-        record_count = 1_000
+    record_count = int(sys.argv[3])
     run_database(database, variant, record_count)

--- a/by-language/python-sqlalchemy/test.py
+++ b/by-language/python-sqlalchemy/test.py
@@ -8,17 +8,19 @@ def run(command: str):
 
 
 def test_insert_efficient_multirow():
-    cmd = "time python insert_efficient.py cratedb multirow 25000"
+    insert_records = 25_000
+    cmd = f"time python insert_efficient.py cratedb multirow {insert_records}"
     run(cmd)
 
 
 def test_insert_efficient_batched():
-    cmd = "time python insert_efficient.py cratedb batched 50000"
+    insert_records = 50_000
+    cmd = f"time python insert_efficient.py cratedb batched {insert_records}"
     run(cmd)
 
 
 def test_insert_efficient_unknown(capfd):
-    cmd = "time python insert_efficient.py cratedb unknown"
+    cmd = "time python insert_efficient.py cratedb unknown 1000"
     with pytest.raises(subprocess.CalledProcessError):
         run(cmd)
     out, err = capfd.readouterr()


### PR DESCRIPTION
## About

> Large inserts without using batch are source of OOMemory, so CrateDB introduced a setting (configurable) to have a protective limit.

In this spirit, large inserts using the "multirow" strategy no longer work, so accompany the test harness to only use them with "batched". In this case, large is ~50_000 records, while ~25_000 records of the shape at hand still work with traditional "multirow" inserts.

## References

- GH-918
