### PR TITLE
Application/Superset: Stop testing Apache Superset 3.x

### DIFF
--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -40,7 +40,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-22.04 ]
-        superset-version: [ "3.*", "4.*" ]
+        superset-version: [
+          # Deactivate testing 3.x until that patch landed.
+          # https://github.com/apache/superset/issues/33162
+          # https://github.com/apache/superset/pull/33216
+          # "3.*",
+          "4.*",
+        ]
         python-version: [ "3.9", "3.11" ]
         cratedb-version: [ 'nightly' ]
 


### PR DESCRIPTION
## About
The fix to make it work would be easy and landed in 4.x already, but upstream doesn't seem to get it into 3.x somehow.

## References
- **Problem:** https://github.com/apache/superset/issues/35942
- **See also:** GH-1192
