### PR TITLE
Application/Superset: Start testing Apache Superset 5.x

### DIFF
--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -52,7 +52,7 @@ jobs:
 
           # Don't test 5.x until there will be a patch release 5.0.1.
           # https://github.com/apache/superset/issues/35942
-          # - '5.*'
+          - "5.*"
 
           # Superset 6.x will work without much ado.
           - '6.0.0rc2'


### PR DESCRIPTION
## About
Apache Superset 5.0.0 was released on Jun 23, 2025.
- https://pypi.org/project/apache-superset/

## Problem
- https://github.com/apache/superset/issues/35942
