### PR TITLE
Framework/Gradio: Downgrade to `huggingface-hub<1` to fix the build

### DIFF
--- a/framework/gradio/requirements.txt
+++ b/framework/gradio/requirements.txt
@@ -1,2 +1,3 @@
 gradio==4.*
+huggingface-hub<1
 sqlalchemy-cratedb>=0.41.0.dev2


### PR DESCRIPTION
## Problem
```python
ImportError: cannot import name 'HfFolder' from 'huggingface_hub'
```
