### PR TITLE
CI: Use Go 1.25

### DIFF
--- a/.github/workflows/lang-go-pgx.yml
+++ b/.github/workflows/lang-go-pgx.yml
@@ -40,6 +40,7 @@ jobs:
         go-version: [
           '1.23.x',
           '1.24.x',
+          '1.25.x',
         ]
 
     services:


### PR DESCRIPTION
[Go 1.25](https://go.dev/doc/go1.25) has been released in August 2025.
