### PR TITLE
Testcontainers/Java: Don't tag the CrateDB JDBC driver as "legacy"

### DIFF
--- a/testing/testcontainers/java/README.rst
+++ b/testing/testcontainers/java/README.rst
@@ -33,9 +33,9 @@ of examples you can explore here:
 - ``TestFunctionScope``: Function-scoped testcontainer instance with automatic setup/teardown, see `Restarted containers`_.
 - ``TestJdbcUrlScheme``: Database containers launched via Testcontainers "TC" JDBC URL scheme.
 - ``TestManual``: Function-scoped testcontainer instance with manual setup/teardown.
-- ``TestManualWithLegacyCrateJdbcDriver``:
+- ``TestManualWithCrateDBJdbcDriver``:
   Function-scoped testcontainer instance with manual setup/teardown, using a custom
-  ``CrateDBContainer``, which uses the `legacy CrateDB JDBC driver`_.
+  ``CrateDBContainer``, which uses the `CrateDB JDBC driver`_.
 - ``TestSharedSingleton``:
   Testcontainer instance shared across multiple test classes, implemented using the Singleton pattern, see `Singleton containers`_.
 - ``TestSharedSingletonEnvironmentVersion``:
@@ -45,6 +45,8 @@ of examples you can explore here:
 - ``TestSqlInitialization``: Demonstrate different ways how Testcontainers can run an init script after
   the database container is started, but before your code initiates a connection to it.
 
+Unless otherwise noted, all examples use the `PostgreSQL JDBC driver`_ for
+connecting to CrateDB.
 
 *****
 Usage
@@ -74,15 +76,16 @@ Usage
     docker run -it --rm --publish=4200:4200 --publish=5432:5432 \
       crate:latest -Cdiscovery.type=single-node
 
-    # Run example program, using both the CrateDB legacy
-    # JDBC driver, and the vanilla PostgreSQL JDBC driver.
+    # Run example program, using both the CrateDB JDBC driver,
+    # and the vanilla PostgreSQL JDBC driver.
     ./gradlew run --args="jdbc:crate://localhost:5432/"
     ./gradlew run --args="jdbc:postgresql://localhost:5432/"
 
 
 .. _CrateDB: https://github.com/crate/crate
+.. _CrateDB JDBC driver: https://cratedb.com/docs/guide/connect/java/cratedb-jdbc.html
 .. _CrateDB OCI image: https://hub.docker.com/_/crate
-.. _legacy CrateDB JDBC driver: https://crate.io/docs/jdbc/
+.. _PostgreSQL JDBC driver: https://cratedb.com/docs/guide/connect/java/postgresql-jdbc.html
 .. _Restarted containers: https://java.testcontainers.org/test_framework_integration/junit_5/#restarted-containers
 .. _Shared containers: https://java.testcontainers.org/test_framework_integration/junit_5/#shared-containers
 .. _Singleton containers: https://java.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers

--- a/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestManualWithCrateDBJdbcDriver.java
+++ b/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestManualWithCrateDBJdbcDriver.java
@@ -14,16 +14,16 @@ import static io.crate.example.testing.utils.TestingHelpers.assertResults;
 
 /**
  * Function-scoped testcontainer instance with manual setup/teardown, using a custom CrateDBContainer which uses
- * the <a href="https://crate.io/docs/jdbc/en/latest/index.html">legacy CrateDB JDBC driver</a>.
+ * the <a href="https://cratedb.com/docs/guide/connect/java/cratedb-jdbc.html">CrateDB JDBC driver</a>.
  * <a href="https://www.testcontainers.org/test_framework_integration/junit_4/#manually-controlling-container-lifecycle" />
  */
-public class TestManualWithLegacyCrateJdbcDriver {
+public class TestManualWithCrateDBJdbcDriver {
 
     @Test
     public void testReadSummits() throws SQLException, IOException {
         // Run CrateDB nightly.
         DockerImageName image = TestingHelpers.nameFromLabel("nightly");
-        try (CrateDBContainerLegacyJdbcDriver cratedb = new CrateDBContainerLegacyJdbcDriver(image)) {
+        try (CrateDBContainerJdbcDriver cratedb = new CrateDBContainerJdbcDriver(image)) {
             cratedb.start();
 
             // Get JDBC URL to CrateDB instance.
@@ -40,7 +40,7 @@ public class TestManualWithLegacyCrateJdbcDriver {
         }
     }
 
-    static class CrateDBContainerLegacyJdbcDriver extends JdbcDatabaseContainer<CrateDBContainerLegacyJdbcDriver> {
+    static class CrateDBContainerJdbcDriver extends JdbcDatabaseContainer<CrateDBContainerJdbcDriver> {
 
         public static final String IMAGE = "crate";
 
@@ -52,7 +52,7 @@ public class TestManualWithLegacyCrateJdbcDriver {
 
         private String password = "crate";
 
-        public CrateDBContainerLegacyJdbcDriver(final DockerImageName dockerImageName) {
+        public CrateDBContainerJdbcDriver(final DockerImageName dockerImageName) {
             super(dockerImageName);
             dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
@@ -100,19 +100,19 @@ public class TestManualWithLegacyCrateJdbcDriver {
         }
 
         @Override
-        public CrateDBContainerLegacyJdbcDriver withDatabaseName(final String databaseName) {
+        public CrateDBContainerJdbcDriver withDatabaseName(final String databaseName) {
             this.databaseName = databaseName;
             return self();
         }
 
         @Override
-        public CrateDBContainerLegacyJdbcDriver withUsername(final String username) {
+        public CrateDBContainerJdbcDriver withUsername(final String username) {
             this.username = username;
             return self();
         }
 
         @Override
-        public CrateDBContainerLegacyJdbcDriver withPassword(final String password) {
+        public CrateDBContainerJdbcDriver withPassword(final String password) {
             this.password = password;
             return self();
         }


### PR DESCRIPTION
## About

We are presenting the PostgreSQL JDBC driver and the CrateDB JDBC driver in parallel now. I think there is no strict need to call the CrateDB driver "legacy", even if the most recent version is currently outdated, because certain applications like Flink currently just need it for certain use cases.

- https://cratedb.com/docs/guide/connect/java/postgresql-jdbc.html
- https://cratedb.com/docs/guide/connect/java/cratedb-jdbc.html

## Details

Extending the rationale above, we are running a full-fledged explanation on the relevant landing page now:

> Prefer the PostgreSQL JDBC driver first, it is often already in your classpath and works out of the box. If your application or framework emits PostgreSQL‑specific SQL that CrateDB doesn’t support, switch to the CrateDB JDBC driver for full CrateDB dialect support and smoother integration.

> For example, the JDBC catalog integration with Apache Flink depends on CrateDB JDBC, in this case we recommend to use that driver depending on your needs.

-- https://cratedb.com/docs/guide/connect/java/

/cc @matriv 