### PR TITLE
Update pytest requirement from <9 to <10

### DIFF
--- a/application/apache-superset/requirements-test.txt
+++ b/application/apache-superset/requirements-test.txt
@@ -1,3 +1,3 @@
 playwright<2
-pytest<9
+pytest<10
 requests<3

--- a/application/cratedb-toolkit/requirements-test.txt
+++ b/application/cratedb-toolkit/requirements-test.txt
@@ -1,4 +1,4 @@
 gitpython<4
 platformdirs<5
-pytest<9
+pytest<10
 requests<3

--- a/application/metabase/requirements-test.txt
+++ b/application/metabase/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest<9
+pytest<10
 pytest-docker-compose-v2<0.2

--- a/application/records/requirements-test.txt
+++ b/application/records/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest<9
+pytest<10

--- a/by-dataframe/dask/requirements-dev.txt
+++ b/by-dataframe/dask/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest<9
+pytest<10
 pytest-cov<8

--- a/by-dataframe/pandas/requirements-dev.txt
+++ b/by-dataframe/pandas/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest<9
+pytest<10
 pytest-cov<8

--- a/by-dataframe/polars/requirements-test.txt
+++ b/by-dataframe/polars/requirements-test.txt
@@ -1,2 +1,2 @@
-pytest<9
+pytest<10
 pytest-cov<8

--- a/by-language/python-connectorx/requirements-dev.txt
+++ b/by-language/python-connectorx/requirements-dev.txt
@@ -1,1 +1,1 @@
-pytest<9
+pytest<10

--- a/by-language/python-dbapi/requirements-dev.txt
+++ b/by-language/python-dbapi/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest<9
+pytest<10
 pytest-cov<8

--- a/by-language/python-sqlalchemy/requirements-dev.txt
+++ b/by-language/python-sqlalchemy/requirements-dev.txt
@@ -1,2 +1,2 @@
-pytest<9
+pytest<10
 pytest-cov<7

--- a/by-language/python-turbodbc/requirements-dev.txt
+++ b/by-language/python-turbodbc/requirements-dev.txt
@@ -1,1 +1,1 @@
-pytest<9
+pytest<10

--- a/framework/dlt/requirements-dev.txt
+++ b/framework/dlt/requirements-dev.txt
@@ -1,3 +1,3 @@
 cratedb-toolkit>=0.0.33
 pueblo[sfa]
-pytest<9
+pytest<10

--- a/framework/gradio/requirements-dev.txt
+++ b/framework/gradio/requirements-dev.txt
@@ -1,2 +1,2 @@
 gradio-client<1.14
-pytest<9
+pytest<10

--- a/framework/records/requirements-test.txt
+++ b/framework/records/requirements-test.txt
@@ -1,1 +1,1 @@
-pytest<9
+pytest<10

--- a/framework/streamlit/requirements-dev.txt
+++ b/framework/streamlit/requirements-dev.txt
@@ -1,1 +1,1 @@
-pytest<9
+pytest<10

--- a/testing/native/python-pytest/requirements.txt
+++ b/testing/native/python-pytest/requirements.txt
@@ -1,4 +1,4 @@
 crash>=0.31.5
 crate>=2.0.0.dev6
-pytest<9
+pytest<10
 pytest-cratedb>=0.4.0

--- a/testing/testcontainers/python-pytest/requirements.txt
+++ b/testing/testcontainers/python-pytest/requirements.txt
@@ -1,4 +1,4 @@
 crash>=0.31.5
 crate>=2.0.0.dev6
 cratedb-toolkit[testing]>=0.0.33
-pytest<9
+pytest<10


### PR DESCRIPTION
## About

Bundle a few Dependabot updates.

## Details

Updates the requirements on [pytest](https://github.com/pytest-dev/pytest) to permit the latest version.
- [Release notes](https://github.com/pytest-dev/pytest/releases)
- [Changelog](https://github.com/pytest-dev/pytest/blob/main/CHANGELOG.rst)
- [Commits](https://github.com/pytest-dev/pytest/compare/1.0.0b3...9.0.0)

---
updated-dependencies:
- dependency-name: pytest dependency-version: 9.0.0 dependency-type: direct:production ...
