### PR TITLE
.NET/CI: Validate on .NET 10.x

### DIFF
--- a/.github/workflows/lang-csharp-efcore.yml
+++ b/.github/workflows/lang-csharp-efcore.yml
@@ -44,6 +44,7 @@ jobs:
         dotnet-version: [
           '8.x',
           '9.x',
+          '10.x',
         ]
         npgsql-version: [
           '8.*',

--- a/.github/workflows/lang-csharp-npgsql.yml
+++ b/.github/workflows/lang-csharp-npgsql.yml
@@ -44,6 +44,7 @@ jobs:
         dotnet-version: [
           '8.x',
           '9.x',
+          '10.x',
         ]
         npgsql-version: [
           '8.*',


### PR DESCRIPTION
## About

.NET 10 was released on November 11, 2025.

- https://devblogs.microsoft.com/dotnet/announcing-dotnet-10/
- https://www.heise.de/en/news/NET-10-0-is-Ready-11075047.html
- https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview

## Problems

We are [receiving](https://github.com/crate/cratedb-examples/actions/runs/19388181700/job/55478008808?pr=1253#step:7:89) this error message:

> /usr/share/dotnet/sdk/10.0.100/Microsoft.Common.CurrentVersion.targets(1259,5): error MSB3644: The reference assemblies for .NETFramework,Version=v1.0 were not found. To resolve this, install the Developer Pack (SDK/Targeting Pack) for this framework version or retarget your application. You can download .NET Framework Developer Packs at https://aka.ms/msbuild/developerpacks [/home/runner/work/cratedb-examples/cratedb-examples/by-language/csharp-npgsql/demo.csproj]

## References
- https://github.com/actions/setup-dotnet/issues/681
- https://github.com/crate/cratedb-examples/issues/1250#issuecomment-3536284262