### PR TITLE
Npgsql/CI: Validate on Npgsql 8.0.8, 9.0.4, and 10.0.0-rc.1

### DIFF
--- a/.github/workflows/lang-csharp-npgsql.yml
+++ b/.github/workflows/lang-csharp-npgsql.yml
@@ -45,7 +45,12 @@ jobs:
           '8.x',
           '9.x',
         ]
-        npgsql-version: [ '8.0.7', '9.0.3' ]
+        # https://github.com/npgsql/npgsql/releases
+        npgsql-version: [
+          '8.0.8',
+          '9.0.4',
+          '10.0.0-rc.1',
+        ]
         cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers


### PR DESCRIPTION
## About
Just maintenance.

## Details
Currently we need to do the version bumping here manually, so relevant changes need to accompany corresponding signals by Dependabot, because the current architecture how Npgsql versions are populated from the test matrix definition requires it.

https://github.com/crate/cratedb-examples/blob/02451753d61e02b94f10084327e4c78d0481ba4f/.github/workflows/lang-csharp-npgsql.yml#L48

https://github.com/crate/cratedb-examples/blob/02451753d61e02b94f10084327e4c78d0481ba4f/.github/workflows/lang-csharp-npgsql.yml#L84-L86