### PR TITLE
.NET/CI: Improve testing, also against pre-release versions of Npgsql

### DIFF
--- a/.github/workflows/lang-csharp-efcore.yml
+++ b/.github/workflows/lang-csharp-efcore.yml
@@ -33,6 +33,7 @@ jobs:
   test:
     name: "
      .NET: ${{ matrix.dotnet-version }}
+     Npgsql EF: ${{ matrix.npgsql-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -43,6 +44,14 @@ jobs:
         dotnet-version: [
           '8.x',
           '9.x',
+        ]
+        npgsql-version: [
+          '8.*',
+          '9.*',
+          # error: NU1202: Package Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0-rc.2
+          # is not compatible with net9.0 (.NETCoreApp,Version=v9.0).
+          # Package Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0-rc.2 supports: net10.0
+          # 'prerelease',
         ]
         cratedb-version: [ 'nightly' ]
 
@@ -61,9 +70,6 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v5
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
       - name: Set up .NET ${{ matrix.dotnet-version }}
         id: dotnet
         uses: actions/setup-dotnet@v5
@@ -79,6 +85,19 @@ jobs:
         run: |
           echo '{"sdk":{"version": "${{ steps.dotnet.outputs.dotnet-version }}"}}' > ./global.json
 
-      - name: Validate by-language/csharp-efcore
+      # Propagate the Npgsql version from the test matrix slot value,
+      # display the current list of packages with versions,
+      # and invoke the test suite.
+      - name: "Validate by-language/csharp-efcore, Npgsql ${{ matrix.npgsql-version }}"
         run: |
-          uv run --with=pueblo ngr test by-language/csharp-efcore --dotnet-version=${{ matrix.dotnet-version }}
+          set -e
+          cd by-language/csharp-efcore
+          if [[ "${{ matrix.npgsql-version }}" = "prerelease" ]]; then
+            dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL --prerelease
+          elif [[ "${{ matrix.npgsql-version }}" = "latest" ]]; then
+            dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL --version=*
+          else
+            dotnet add package Npgsql.EntityFrameworkCore.PostgreSQL --version=${{ matrix.npgsql-version }}
+          fi
+          dotnet list package
+          dotnet run test

--- a/.github/workflows/lang-csharp-npgsql.yml
+++ b/.github/workflows/lang-csharp-npgsql.yml
@@ -45,7 +45,11 @@ jobs:
           '8.x',
           '9.x',
         ]
-        npgsql-version: [ '8.0.7', '9.0.3' ]
+        npgsql-version: [
+          '8.*',
+          '9.*',
+          'prerelease',
+        ]
         cratedb-version: [ 'nightly' ]
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
@@ -63,9 +67,6 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v5
 
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-
       - name: Set up .NET ${{ matrix.dotnet-version }}
         id: dotnet
         uses: actions/setup-dotnet@v5
@@ -81,6 +82,19 @@ jobs:
         run: |
           echo '{"sdk":{"version": "${{ steps.dotnet.outputs.dotnet-version }}"}}' > ./global.json
 
-      - name: Validate by-language/csharp-npgsql, Npgsql ${{ matrix.npgsql-version }}
+      # Propagate the Npgsql version from the test matrix slot value,
+      # display the current list of packages with versions,
+      # and invoke the test suite.
+      - name: "Validate by-language/csharp-npgsql, Npgsql ${{ matrix.npgsql-version }}"
         run: |
-          uv run --with=pueblo ngr test by-language/csharp-npgsql --dotnet-version=${{ matrix.dotnet-version }} --npgsql-version=${{ matrix.npgsql-version }}
+          set -e
+          cd by-language/csharp-npgsql
+          if [[ "${{ matrix.npgsql-version }}" = "prerelease" ]]; then
+            dotnet add package Npgsql --prerelease
+          elif [[ "${{ matrix.npgsql-version }}" = "latest" ]]; then
+            dotnet add package Npgsql --version=*
+          else
+            dotnet add package Npgsql --version=${{ matrix.npgsql-version }}
+          fi
+          dotnet list package
+          dotnet run test


### PR DESCRIPTION
## About

Improve integration testing with Npgsql.

## Details

With the drawback of introducing redundancies by retiring the use of the universal test runner `ngr` in this case, the CI workflow recipe gains the benefit of being able to directly manipulate the version numbers of dependency packages.

This improves the setup, because the test suite can now be validated against pre-release versions of the Npgsql package.
Npgsql is important for CrateDB, because the .NET connectivity relies on it, provided by its PostgreSQL wire compatibility.
