### PR TITLE
Testing/Python: Use macOS 15 (Intel) and Python 3.14 on CI

### DIFF
--- a/.github/workflows/testing-native-python.yml
+++ b/.github/workflows/testing-native-python.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest', 'macos-15-intel' ]
-        python-version: [ '3.8', '3.12' ]
+        python-version: [ '3.8', '3.14' ]
         cratedb-version: [ 'nightly' ]
 
     env:


### PR DESCRIPTION
## About
- [Testing/Python: Use macOS 15 (Intel) on CI](https://github.com/crate/cratedb-examples/commit/83cd89c33c6da6e0041c2dcc0fb7b2b6ef1716c1)
- [Testing/Python: Use Python 3.14 on CI](https://github.com/crate/cratedb-examples/commit/03cb37dc4c5a64709d63d7207a508bf92adb68d9)

## Why?

Python: 3.12 CrateDB: nightly on macos-13
The macOS-13 based runner images are now retired. For more details, see https://github.com/actions/runner-images/issues/13046.

Python: 3.12 CrateDB: nightly on macos-13
The macOS-13 based runner images are being deprecated, consider switching to macOS-15 (macos-15-intel) or macOS 15 arm64 (macos-latest) instead. For more details see https://github.com/actions/runner-images/issues/13046.

-- https://github.com/crate/cratedb-examples/actions/runs/20050876789
