### PR TITLE
R: Don't use database name when connecting

### DIFF
--- a/by-language/r/basic_rpostgres.r
+++ b/by-language/r/basic_rpostgres.r
@@ -19,7 +19,6 @@ conn <- dbConnect(drv,
                   sslmode = "disable",
                   user = "crate",
                   password = "crate",
-                  dbname = "doc",
                   )
 on.exit(DBI::dbDisconnect(conn), add = TRUE)
 

--- a/by-language/r/basic_rpostgresql.r
+++ b/by-language/r/basic_rpostgresql.r
@@ -18,7 +18,6 @@ conn <- dbConnect(drv,
                  port = 5432,
                  user = "crate",
                  password = "crate",
-                 dbname = "doc",
                  )
 on.exit(DBI::dbDisconnect(conn), add = TRUE)
 


### PR DESCRIPTION
It would give users a wrong impression.
