### PR TITLE
Dataframes: Permit installation of pandas v3.0

### DIFF
--- a/by-dataframe/dask/insert_dask.py
+++ b/by-dataframe/dask/insert_dask.py
@@ -37,7 +37,7 @@ def db_workload(dburi: str, mode: str, num_records: int, bulk_size: int):
     pbar.register()
 
     # Create example Dask DataFrame for testing purposes.
-    df = makeTimeDataFrame(nper=num_records, freq="S")
+    df = makeTimeDataFrame(nper=num_records, freq="s")
     ddf = dd.from_pandas(df, npartitions=4)
 
     # Save DataFrame into CrateDB efficiently.

--- a/by-dataframe/dask/requirements.txt
+++ b/by-dataframe/dask/requirements.txt
@@ -2,6 +2,6 @@ click<9
 colorlog<7
 dask[dataframe]>=2024.4.1   # Python 3.11.9 breaks previous Dask
 distributed>=2024.4.1       # Python 3.11.9 breaks previous Dask
-pandas<3
+pandas<3.1
 pueblo>=0.0.10
 sqlalchemy-cratedb>=0.41.0.dev2

--- a/by-dataframe/pandas/insert_pandas.py
+++ b/by-dataframe/pandas/insert_pandas.py
@@ -78,7 +78,7 @@ class DatabaseWorkload:
         logger.info(f"Creating DataFrame with {num_records} records")
 
         # Create a DataFrame to feed into the database.
-        df = makeTimeDataFrame(nper=num_records, freq="S")
+        df = makeTimeDataFrame(nper=num_records, freq="s")
         print(df)
 
         logger.info(f"Connecting to {self.dburi}")

--- a/by-dataframe/pandas/requirements.txt
+++ b/by-dataframe/pandas/requirements.txt
@@ -1,6 +1,6 @@
 click<9
 colorlog<7
 crate>=2.0.0.dev6
-pandas==2.3.*
+pandas>=2.3,<3.1
 pueblo>=0.0.10
 sqlalchemy-cratedb[all] @ git+https://github.com/crate-workbench/sqlalchemy-cratedb@amo/postgresql-async


### PR DESCRIPTION
## About
Make examples ready for pandas 3, released on Jan 21, 2026.

## References
- GH-1362
- GH-1377
