### PR TITLE
Pgpool-II: Downgrade to CrateDB 6.1.3

### DIFF
--- a/application/pgpool/compose.yml
+++ b/application/pgpool/compose.yml
@@ -17,7 +17,7 @@ services:
   # Daemon services
   # ---------------
   cratedb:
-    image: docker.io/crate/crate:nightly
+    image: docker.io/crate/crate:6.1.3
     command: >
       crate \
         '-Cdiscovery.type=single-node' \
@@ -57,7 +57,7 @@ services:
   # Utility programs
   # ----------------
   crash:
-    image: docker.io/crate/crate:nightly
+    image: docker.io/crate/crate:6.1.3
     command: |
       crash --hosts "http://cratedb:4200"
     deploy:
@@ -69,7 +69,7 @@ services:
 
   # CrateDB lacks two functions which can easily be substituted using UDFs.
   provision-functions:
-    image: docker.io/crate/crate:nightly
+    image: docker.io/crate/crate:6.1.3
     entrypoint: /bin/bash -c
     command:
       - |


### PR DESCRIPTION
## Problem
```
FATAL:  Backend throw an error message
DETAIL:  Exiting current session because of an error from backend HINT:  BACKEND Error: "Function: 'pgpool_regclass(cstring)' does not exist" server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.
connection to server was lost
```

## References
- https://github.com/crate/crate/issues/18995
- https://github.com/crate/cratedb-examples/pull/1417