### PR TITLE
CI: Validate .NET 11

### DIFF
--- a/.github/workflows/lang-csharp-efcore.yml
+++ b/.github/workflows/lang-csharp-efcore.yml
@@ -45,6 +45,7 @@ jobs:
           '8.x',
           '9.x',
           '10.x',
+          '11.x',
         ]
         npgsql-version: [
           '8.*',
@@ -54,8 +55,9 @@ jobs:
         ]
         cratedb-version: [ 'nightly' ]
 
-        # Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0 and higher needs .NET10.
         exclude:
+
+          # Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0 and higher needs .NET10.
           - dotnet-version: '8.x'
             npgsql-version: '10.*'
           - dotnet-version: '8.x'
@@ -64,6 +66,14 @@ jobs:
             npgsql-version: '10.*'
           - dotnet-version: '9.x'
             npgsql-version: 'prerelease'
+
+          # Npgsql.EntityFrameworkCore.PostgreSQL 11.0.0 is not compatible with .NET10.
+          - dotnet-version: '10.x'
+            npgsql-version: 'prerelease'
+
+          # Npgsql.EntityFrameworkCore.PostgreSQL 10.0.0 is not compatible with .NET11.
+          - dotnet-version: '11.x'
+            npgsql-version: '10.*'
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:

--- a/.github/workflows/lang-csharp-npgsql.yml
+++ b/.github/workflows/lang-csharp-npgsql.yml
@@ -45,6 +45,7 @@ jobs:
           '8.x',
           '9.x',
           '10.x',
+          '11.x',
         ]
         npgsql-version: [
           '8.*',
@@ -53,6 +54,14 @@ jobs:
           'prerelease',
         ]
         cratedb-version: [ 'nightly' ]
+
+        exclude:
+
+          # .NET11 needs Npgsql.PostgreSQL 10.0.0 and higher.
+          - dotnet-version: '11.x'
+            npgsql-version: '8.*'
+          - dotnet-version: '11.x'
+            npgsql-version: '9.*'
 
     # https://docs.github.com/en/free-pro-team@latest/actions/guides/about-service-containers
     services:


### PR DESCRIPTION
## Problem
```
error: NU1202: Package Npgsql.EntityFrameworkCore.PostgreSQL 11.0.0-preview.1 is not compatible with net10.0 (.NETCoreApp,Version=v10.0). Package Npgsql.EntityFrameworkCore.PostgreSQL 11.0.0-preview.1 supports: net11.0 (.NETCoreApp,Version=v11.0)
error: Package 'Npgsql.EntityFrameworkCore.PostgreSQL' is incompatible with 'all' frameworks in project '/home/runner/work/cratedb-examples/cratedb-examples/by-language/csharp-efcore/demo.csproj'.
Error: Process completed with exit code 1.
```
-- [CI run #21892205177](https://github.com/crate/cratedb-examples/actions/runs/21892205177/job/63200275841)

<img width="188" height="37" alt="image" src="https://github.com/user-attachments/assets/041811d5-9cc1-4313-869b-613592824555" />


-- [Build status](https://cratedb.com/docs/guide/integrate/status.html)