### PR TITLE
Pgpool-II: Update to CrateDB nightly for improved regression testing

### DIFF
--- a/application/pgpool/compose.yml
+++ b/application/pgpool/compose.yml
@@ -17,7 +17,7 @@ services:
   # Daemon services
   # ---------------
   cratedb:
-    image: docker.io/crate/crate:6.2.3
+    image: docker.io/crate/crate:nightly
     command: >
       crate \
         '-Cdiscovery.type=single-node' \
@@ -57,7 +57,7 @@ services:
   # Utility programs
   # ----------------
   crash:
-    image: docker.io/crate/crate:6.2.3
+    image: docker.io/crate/crate:nightly
     command: |
       crash --hosts "http://cratedb:4200"
     deploy:
@@ -69,7 +69,7 @@ services:
 
   # CrateDB lacks two functions which can easily be substituted using UDFs.
   provision-functions:
-    image: docker.io/crate/crate:6.2.3
+    image: docker.io/crate/crate:nightly
     entrypoint: /bin/bash -c
     command:
       - |


### PR DESCRIPTION
## About
Demonstrate a regression with recent CrateDB nightly.
```
BACKEND Error: "Function: 'pgpool_regclass(cstring)' does not exist"
```
-- [CI run #21911345462](https://github.com/crate/cratedb-examples/actions/runs/21911345462/job/63265869970?pr=1418#step:3:670)

## Details
First spotted on Feb 3, 4:49 AM GMT+1 on the [Pgpool-II integration test workflow](https://github.com/crate/cratedb-examples/actions/workflows/application-pgpool.yml) with [CI run #21616183750](https://github.com/crate/cratedb-examples/actions/runs/21616183750).

## References
- Root cause: https://github.com/crate/crate/issues/18995
- Workaround: GH-1417
