### PR TITLE
CI: Activate all Apache Superset versions

### DIFF
--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -55,7 +55,8 @@ jobs:
           # - '5.*'
 
           # Superset 6.x will work without much ado.
-          - '6.0.0rc2'
+          - '6.*'
+
         python-version:
           - '3.9'
           - '3.11'
@@ -64,14 +65,14 @@ jobs:
 
         exclude:
           # Apache Superset 6.x no longer supports Python 3.9.
-          - superset-version: "6.0.0rc2"
+          - superset-version: "6.*"
             python-version: "3.9"
 
         include:
           # Apache Superset 6.x supports Python 3.12.
           - os: "ubuntu-latest"
             cratedb-version: "nightly"
-            superset-version: "6.0.0rc2"
+            superset-version: "6.*"
             python-version: "3.12"
 
 

--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -45,14 +45,14 @@ jobs:
           # Deactivate testing 3.x until that patch landed.
           # https://github.com/apache/superset/issues/33162
           # https://github.com/apache/superset/pull/33216
-          # - '3.*'
+          - '3.*'
 
           # Superset 4.x has been fixed.
           - '4.*'
 
           # Don't test 5.x until there will be a patch release 5.0.1.
           # https://github.com/apache/superset/issues/35942
-          # - '5.*'
+          - '5.*'
 
           # Superset 6.x will work without much ado.
           - '6.*'


### PR DESCRIPTION
## About
Validate integration tests against active and inactive versions of Apache Superset 3.x-6.x.

## References
- https://github.com/apache/superset/issues/20546
- https://github.com/apache/superset/issues/35942
