### PR TITLE
CI: Start adding random delays to scheduled jobs to avoid overloading

### DIFF
--- a/.github/workflows/application-apache-superset.yml
+++ b/.github/workflows/application-apache-superset.yml
@@ -86,6 +86,13 @@ jobs:
 
     steps:
 
+      - name: Delay scheduled job to avoid overloading
+        if: ${{ github.event.schedule }}
+        uses: AliSajid/random-wait-action@v2.11.1
+        with:
+          minimum: 1
+          maximum: 120
+
       - name: Acquire sources
         uses: actions/checkout@v6
 

--- a/.github/workflows/application-cratedb-toolkit.yml
+++ b/.github/workflows/application-cratedb-toolkit.yml
@@ -60,6 +60,13 @@ jobs:
 
     steps:
 
+      - name: Delay scheduled job to avoid overloading
+        if: ${{ github.event.schedule }}
+        uses: AliSajid/random-wait-action@v2.11.1
+        with:
+          minimum: 1
+          maximum: 120
+
       - name: Acquire sources
         uses: actions/checkout@v6
 


### PR DESCRIPTION
Starting all GHA workflows at the same time causes peaks in resource demands.
The crontab syntax does not accept adding jitter to the "minute" component.
@AliSajid conceived a GitHub Action recipe https://github.com/AliSajid/random-wait-action that can be used instead. 🙇 