### PR TITLE
Go: Update to Golang 1.26

### DIFF
--- a/.github/workflows/lang-go-pgx.yml
+++ b/.github/workflows/lang-go-pgx.yml
@@ -37,10 +37,9 @@ jobs:
       matrix:
         os: [ 'ubuntu-latest' ]
         cratedb-version: [ 'nightly' ]
-        go-version: [
-          '1.24.x',
-          '1.25.x',
-        ]
+        go-version:
+          - '1.25.x'
+          - '1.26.x'
 
     services:
       cratedb:

--- a/by-language/go-pgx/go.mod
+++ b/by-language/go-pgx/go.mod
@@ -1,8 +1,6 @@
 module github.com/cratedb-examples/by-language/go-pgx
 
-go 1.24.0
-
-toolchain go1.24.1
+go 1.25.0
 
 require github.com/jackc/pgx/v5 v5.8.0
 


### PR DESCRIPTION
Go 1.26.0 was released on 2026-02-10.