### PR TITLE
pgx: Start validating PostgreSQL protocol version 3.2

### DIFF
--- a/.github/workflows/lang-go-pgx.yml
+++ b/.github/workflows/lang-go-pgx.yml
@@ -29,14 +29,18 @@ jobs:
   test:
     name: "
      Go: ${{ matrix.go-version }}
+     Protocol: ${{ matrix.postgresql-protocol-version }}
      CrateDB: ${{ matrix.cratedb-version }}
-     on ${{ matrix.os }}"
+    "
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ 'ubuntu-latest' ]
         cratedb-version: [ 'nightly' ]
+        postgresql-protocol-version:
+          - '3.0'
+          - '3.2'
         go-version:
           - '1.25.x'
           - '1.26.x'
@@ -65,4 +69,5 @@ jobs:
 
       - name: Validate by-language/go-pgx
         run: |
-          uv run --with=pueblo ngr test by-language/go-pgx
+          cd by-language/go-pgx
+          go run . --protocol-version="${{ matrix.postgresql-protocol-version }}"

--- a/by-language/go-pgx/main.go
+++ b/by-language/go-pgx/main.go
@@ -8,8 +8,11 @@ import (
 func main() {
 	hosts := flag.String("hosts", "localhost", "CrateDB hostname")
 	port := flag.Int("port", 5432, "CrateDB postgres port")
+	protocol_version := flag.String("protocol-version", "3.0", "PostgreSQL protocol version")
 	flag.Parse()
-	connStr := fmt.Sprintf("postgres://crate@%s:%d/testdrive", *hosts, *port)
+	connStr := fmt.Sprintf(
+	    "postgres://crate@%s:%d/testdrive?min_protocol_version=%s&max_protocol_version=%s",
+	    *hosts, *port, *protocol_version, *protocol_version)
 	runBasicQueries(connStr)
 	runBulkOperations(connStr)
 }


### PR DESCRIPTION
## About
PostgreSQL 18 added a new protocol version, version 3.2. pgx v5.9.0 added support for it, optionally to be enabled/configured using the new `min_protocol_version` and `max_protocol_version` options. By default, pgx will still use protocol version 3.0 like before.

## Details
The corresponding announcement in the pgx v5.9.0 change log sounds interesting, it [says](https://github.com/jackc/pgx/blob/v5.9.0/CHANGELOG.md?plain=1#L6-L7):

> It significantly reduces the amount of network traffic when using prepared statements (which are used automatically by default) by avoiding unnecessary Describe Portal messages. This also reduces local memory usage.

## References
- https://github.com/crate/crate/issues/19175
- https://github.com/crate/cratedb-examples/pull/1507
- Upstream feature: https://github.com/jackc/pgx/issues/2489
- Currently blocked by GH-1490, see https://github.com/crate/crate-clients-tools/issues/306.
