### PR TITLE
Rust: Update to postgres 0.19.12

### DIFF
--- a/by-language/rust-postgres/Cargo.toml
+++ b/by-language/rust-postgres/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["The CrateDB Developers"]
 edition = "2021"
 
 [dependencies]
-postgres = "0.19.7"
+postgres = "0.19.12"


### PR DESCRIPTION
Just a version bump.