### PR TITLE
jdbc: Start validating PostgreSQL protocol version 3.2

### DIFF
--- a/.github/workflows/lang-java-maven.yml
+++ b/.github/workflows/lang-java-maven.yml
@@ -32,6 +32,7 @@ jobs:
   test:
     name: "
      Java: ${{ matrix.java-version }}
+     Protocol: ${{ matrix.postgresql-protocol-version }}
      CrateDB: ${{ matrix.cratedb-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -45,7 +46,13 @@ jobs:
           '21',
           '25',
         ]
+        postgresql-protocol-version:
+          - '3.0'
+          - '3.2'
         cratedb-version: [ 'nightly' ]
+
+    env:
+      POSTGRESQL_PROTOCOL_VERSION: ${{ matrix.postgresql-protocol-version }}
 
     services:
       cratedb:

--- a/by-language/java-jdbc/Makefile
+++ b/by-language/java-jdbc/Makefile
@@ -1,3 +1,0 @@
-test:
-	mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://localhost:5432/testdrive'"
-	mvn exec:java -Dexec.args="--dburl 'jdbc:crate://localhost:5432/testdrive'"

--- a/by-language/java-jdbc/test.sh
+++ b/by-language/java-jdbc/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+set -e
+
+mvn exec:java -Dexec.args="--dburl 'jdbc:postgresql://localhost:5432/testdrive?protocolVersion=${POSTGRESQL_PROTOCOL_VERSION:-3.0}'"
+mvn exec:java -Dexec.args="--dburl 'jdbc:crate://localhost:5432/testdrive'"

--- a/by-language/java-qa/src/test/java/io/crate/qa/JdbcMetaDataTest.java
+++ b/by-language/java-qa/src/test/java/io/crate/qa/JdbcMetaDataTest.java
@@ -28,7 +28,8 @@ public class JdbcMetaDataTest {
         .fromURL("https://cdn.crate.io/downloads/releases/nightly/crate-latest.tar.gz")
         .settings(Map.of("psql.port", 55432))
         .build();
-    public static final String URL = "jdbc:postgresql://localhost:55432/testdrive?user=crate";
+    static String protocol_version = System.getenv().getOrDefault("POSTGRESQL_PROTOCOL_VERSION", "3.0");
+    public static final String URL = "jdbc:postgresql://localhost:55432/testdrive?user=crate&protocolVersion=" + protocol_version;
 
     @Test
     public void test_allProceduresAreCallable() throws Exception {

--- a/by-language/java-qa/src/test/java/io/crate/qa/JdbcTest.java
+++ b/by-language/java-qa/src/test/java/io/crate/qa/JdbcTest.java
@@ -23,7 +23,8 @@ public class JdbcTest {
         .fromURL("https://cdn.crate.io/downloads/releases/nightly/crate-latest.tar.gz")
         .settings(Map.of("psql.port", 55433))
         .build();
-    public static final String URL = "jdbc:postgresql://localhost:55433/testdrive?user=crate";
+    static String protocol_version = System.getenv().getOrDefault("POSTGRESQL_PROTOCOL_VERSION", "3.0");
+    public static final String URL = "jdbc:postgresql://localhost:55433/testdrive?user=crate&protocolVersion=" + protocol_version;
 
     @After
     public void after() throws Exception {


### PR DESCRIPTION
## About
PostgreSQL 18 added a new protocol version, version 3.2. The PostgreSQL JDBC driver was accompanied with the `protocolVersion` option that can be used within the database connection URL. By default, PostgreSQL JDBC will still use protocol version 3.0 like before.

## Details
The corresponding announcement in the pgx v5.9.0 change log sounds interesting, it [says](https://github.com/jackc/pgx/blob/v5.9.0/CHANGELOG.md?plain=1#L6-L7):

> It significantly reduces the amount of network traffic when using prepared statements (which are used automatically by default) by avoiding unnecessary Describe Portal messages. This also reduces local memory usage.

## References

- https://github.com/crate/crate/issues/19175
- https://github.com/crate/cratedb-examples/pull/1494
