### PR TITLE
ingestr: Use Xonsh 0.22 until adjusted for 0.23

### DIFF
--- a/application/ingestr/test.sh
+++ b/application/ingestr/test.sh
@@ -18,7 +18,9 @@ function setup() {
 
 # Invoke Kafka tests.
 function test_kafka() {
-  xonsh kafka-demo.xsh
+  # Use specific version of Xonsh until #6354 is resolved.
+  # https://github.com/xonsh/xonsh/issues/6354
+  uvx 'xonsh==0.22.*' kafka-demo.xsh
 }
 
 # Invoke Elasticsearch tests.


### PR DESCRIPTION
## About
Downgrade to the previous version of Xonsh due to changed language semantics including breaking changes with version 0.23.0.
```
uvx 'xonsh==0.22.*' kafka-demo.xsh
```

## References
- https://github.com/xonsh/xonsh/issues/6354
