### PR TITLE
LangChain: Fix dependencies around `langgraph` package

### DIFF
--- a/topic/machine-learning/langchain/requirements.txt
+++ b/topic/machine-learning/langchain/requirements.txt
@@ -7,7 +7,7 @@ langchain-google-vertexai<4
 langchain-openai<1.2
 langchain-text-splitters<1.2
 langgraph<1.2
-langgraph-prebuilt!=1.0.9
+langgraph-prebuilt<1.0.9
 nltk<4
 pueblo[cli,nlp]>=0.0.18
 pypdf<7


### PR DESCRIPTION
## About
CI went south due to upstream dependency woes.

## References
- https://github.com/langchain-ai/langgraph/issues/7404