### PR TITLE
CrateDB version maintenance 202604

### DIFF
--- a/application/ingestr/elasticsearch-compose.yml
+++ b/application/ingestr/elasticsearch-compose.yml
@@ -26,7 +26,7 @@ services:
   # CrateDB
   # -------
   cratedb:
-    image: docker.io/crate:6.2.6
+    image: docker.io/crate/crate:nightly
     ports:
       - "${CRATEDB_HTTP_PORT}:${CRATEDB_HTTP_PORT}"
       - "${CRATEDB_POSTGRESQL_PORT}:${CRATEDB_POSTGRESQL_PORT}"
@@ -90,7 +90,7 @@ services:
 
   # Query data in CrateDB.
   cratedb-query:
-    image: docker.io/crate:6.2.6
+    image: docker.io/crate/crate:nightly
     entrypoint: ""
     command: >
       crash --hosts cratedb -c "SELECT * FROM doc.example LIMIT 10"

--- a/application/ingestr/kafka-compose.yml
+++ b/application/ingestr/kafka-compose.yml
@@ -43,7 +43,7 @@ services:
   # CrateDB
   # -------
   cratedb:
-    image: docker.io/crate:6.2.6
+    image: docker.io/crate/crate:nightly
     ports:
       - "${CRATEDB_HTTP_PORT}:${CRATEDB_HTTP_PORT}"
       - "${CRATEDB_POSTGRESQL_PORT}:${CRATEDB_POSTGRESQL_PORT}"

--- a/application/metabase/docker-compose.yml
+++ b/application/metabase/docker-compose.yml
@@ -25,7 +25,7 @@ services:
   # CrateDB
   # https://github.com/crate/crate
   cratedb:
-    image: crate/crate:nightly
+    image: docker.io/crate/crate:nightly
     container_name: cratedb
     hostname: cratedb
     ports:

--- a/application/tinyetl/files-compose.yml
+++ b/application/tinyetl/files-compose.yml
@@ -91,7 +91,7 @@ services:
 
   # Reset data in CrateDB.
   cratedb-reset:
-    image: docker.io/crate:6.1.2
+    image: docker.io/crate/crate:nightly
     entrypoint: ["/bin/sh", "-c"]
     command: >
       """
@@ -107,7 +107,7 @@ services:
 
   # Query data in CrateDB.
   cratedb-query:
-    image: docker.io/crate:6.1.2
+    image: docker.io/crate/crate:nightly
     entrypoint: ["/bin/sh", "-c"]
     command: >
       """

--- a/by-language/java-quarkus-panache/src/test/java/io/crate/test/CrateDBTestResource.java
+++ b/by-language/java-quarkus-panache/src/test/java/io/crate/test/CrateDBTestResource.java
@@ -38,6 +38,6 @@ public class CrateDBTestResource implements QuarkusTestResourceLifecycleManager 
     }
 
     public static DockerImageName dockerImageLatest() {
-        return DockerImageName.parse("crate:latest").asCompatibleSubstituteFor("crate");
+        return DockerImageName.parse("docker.io/crate/crate:nightly").asCompatibleSubstituteFor("crate");
     }
 }

--- a/by-language/java-quarkus-panache/src/test/java/io/crate/test/CrateDBTestResource.java
+++ b/by-language/java-quarkus-panache/src/test/java/io/crate/test/CrateDBTestResource.java
@@ -32,12 +32,12 @@ public class CrateDBTestResource implements QuarkusTestResourceLifecycleManager 
 
     private void startContainer() {
         // Run CrateDB latest.
-        DockerImageName image = dockerImageLatest();
+        DockerImageName image = dockerImageNightly();
         cratedb = new CrateDBContainer(image);
         cratedb.start();
     }
 
-    public static DockerImageName dockerImageLatest() {
+    public static DockerImageName dockerImageNightly() {
         return DockerImageName.parse("docker.io/crate/crate:nightly").asCompatibleSubstituteFor("crate");
     }
 }

--- a/by-language/ruby/README.rst
+++ b/by-language/ruby/README.rst
@@ -23,7 +23,7 @@ Usage
 
 Run CrateDB::
 
-    docker run -it --rm --publish=4200:4200 --publish=5432:5432 crate:5.1.1
+    docker run -it --rm --publish=4200:4200 --publish=5432:5432 docker.io/crate:latest
 
 Install example program::
 

--- a/framework/flink/kafka-jdbcsink-java/docker-compose.yml
+++ b/framework/flink/kafka-jdbcsink-java/docker-compose.yml
@@ -111,7 +111,7 @@ services:
   # CrateDB
   # -------
   cratedb:
-    image: crate:${CRATEDB_VERSION}
+    image: docker.io/crate/crate:${CRATEDB_VERSION:-nightly}
     ports:
       - "${CRATEDB_HTTP_PORT}:${CRATEDB_HTTP_PORT}"
       - "${CRATEDB_POSTGRESQL_PORT}:${CRATEDB_POSTGRESQL_PORT}"

--- a/framework/flink/kafka-jdbcsink-python/docker-compose.yml
+++ b/framework/flink/kafka-jdbcsink-python/docker-compose.yml
@@ -28,7 +28,7 @@ services:
         condition: service_healthy
 
   crate:
-    image: crate:latest
+    image: docker.io/crate/crate:${CRATEDB_VERSION:-nightly}
     ports:
       - "4200:4200"
     command: [ "crate",

--- a/operation/compose/ssl/compose.yml
+++ b/operation/compose/ssl/compose.yml
@@ -5,7 +5,7 @@ name: cratedb-with-ssl
 services:
 
   cratedb:
-    image: crate/crate:nightly
+    image: docker.io/crate/crate:nightly
     command: ["crate", "-Cstats.enabled=true"]
     ports:
       - 4200:4200

--- a/operation/http-api-behind-nginx/README.rst
+++ b/operation/http-api-behind-nginx/README.rst
@@ -17,7 +17,7 @@ Usage
 
 Start CrateDB::
 
-    docker run -it --rm --publish=4200:4200 --publish=5432:5432 --name=cratedb crate/crate:5.0.1 -Cdiscovery.type=single-node -Ccluster.routing.allocation.disk.threshold_enabled=false
+    docker run -it --rm --publish=4200:4200 --publish=5432:5432 --name=cratedb docker.io/crate:latest -Cdiscovery.type=single-node -Ccluster.routing.allocation.disk.threshold_enabled=false
 
 Start Nginx::
 

--- a/operation/testbench-yellowcab/cratedb-import-nyc-yellowcab.sh
+++ b/operation/testbench-yellowcab/cratedb-import-nyc-yellowcab.sh
@@ -12,7 +12,7 @@
 
 # 0. Define variables.
 CONTAINER_NAME=${CONTAINER_NAME:-cratedb}
-CRATEDB_IMAGE=${CRATEDB_IMAGE:-docker.io/crate/crate:nightly}
+CRATEDB_IMAGE=${CRATEDB_IMAGE:-docker.io/crate:latest}
 
 # 0. Sanity checks
 if [ ! $(command -v docker) ]; then

--- a/operation/testbench-yellowcab/cratedb-import-nyc-yellowcab.sh
+++ b/operation/testbench-yellowcab/cratedb-import-nyc-yellowcab.sh
@@ -12,7 +12,7 @@
 
 # 0. Define variables.
 CONTAINER_NAME=${CONTAINER_NAME:-cratedb}
-CRATEDB_IMAGE=${CRATEDB_IMAGE:-crate:4.8.1}
+CRATEDB_IMAGE=${CRATEDB_IMAGE:-docker.io/crate/crate:nightly}
 
 # 0. Sanity checks
 if [ ! $(command -v docker) ]; then

--- a/testing/testcontainers/java/README.rst
+++ b/testing/testcontainers/java/README.rst
@@ -66,7 +66,7 @@ Usage
     ./gradlew test --tests TestFunctionScope --info
 
     # Run test case showing how to select CrateDB version per environment variable.
-    export CRATEDB_VERSION=5.10.3
+    export CRATEDB_VERSION=6.2
     export CRATEDB_VERSION=nightly
     ./gradlew test --tests TestSqlInitialization
 

--- a/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestClassScope.java
+++ b/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestClassScope.java
@@ -27,7 +27,7 @@ import static io.crate.example.testing.utils.TestingHelpers.assertResults;
 public class TestClassScope {
 
     @Container
-    public static CrateDBContainer cratedb = new CrateDBContainer(TestingHelpers.nameFromLabel("5.10"));
+    public static CrateDBContainer cratedb = new CrateDBContainer(TestingHelpers.nameFromLabel("6.2"));
 
     @Test
     public void testReadSummits() throws SQLException, IOException {

--- a/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestFunctionScope.java
+++ b/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestFunctionScope.java
@@ -27,7 +27,7 @@ import static io.crate.example.testing.utils.TestingHelpers.assertResults;
 public class TestFunctionScope {
 
     @Container
-    public CrateDBContainer cratedb = new CrateDBContainer(TestingHelpers.nameFromLabel("5.10"));
+    public CrateDBContainer cratedb = new CrateDBContainer(TestingHelpers.nameFromLabel("6.2"));
 
     @Test
     public void testReadSummits() throws SQLException, IOException {

--- a/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestJdbcUrlScheme.java
+++ b/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestJdbcUrlScheme.java
@@ -38,7 +38,7 @@ public class TestJdbcUrlScheme {
     public void testReadSummitsCrateDB() throws SQLException, IOException {
         // NOTE: Please note `jdbc:tc:crate` will not work, only `jdbc:tc:cratedb`.
         //       => `java.lang.UnsupportedOperationException: Database name crate not supported`
-        String connectionUrl = "jdbc:tc:cratedb:5.10://localhost/doc?user=crate";
+        String connectionUrl = "jdbc:tc:cratedb:6.2://localhost/doc?user=crate";
         System.out.printf("Connecting to %s%n", connectionUrl);
 
         // Invoke example query.
@@ -53,7 +53,7 @@ public class TestJdbcUrlScheme {
      */
     @Test
     public void testReadSummitsCrateDBWithDaemon() throws SQLException, IOException {
-        String connectionUrl = "jdbc:tc:cratedb:5.10://localhost/doc?user=crate&TC_DAEMON=true";
+        String connectionUrl = "jdbc:tc:cratedb:6.2://localhost/doc?user=crate&TC_DAEMON=true";
         System.out.printf("Connecting to %s%n", connectionUrl);
 
         // Invoke example query.
@@ -68,7 +68,7 @@ public class TestJdbcUrlScheme {
      */
     @Test
     public void testReadSummitsCrateDBWithReuse() throws SQLException, IOException {
-        String connectionUrl = "jdbc:tc:cratedb:5.10://localhost/doc?user=crate&TC_REUSABLE=true";
+        String connectionUrl = "jdbc:tc:cratedb:6.2://localhost/doc?user=crate&TC_REUSABLE=true";
         System.out.printf("Connecting to %s%n", connectionUrl);
 
         // Invoke example query.

--- a/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestSqlInitialization.java
+++ b/testing/testcontainers/java/src/test/java/io/crate/example/testing/TestSqlInitialization.java
@@ -23,7 +23,7 @@ public class TestSqlInitialization {
      */
     @Test
     public void testTcInitClasspathFile() throws SQLException, IOException {
-        String connectionUrl = "jdbc:tc:cratedb:5.10://localhost/doc?user=crate&TC_REUSABLE=true&TC_INITSCRIPT=init.sql";
+        String connectionUrl = "jdbc:tc:cratedb:6.2://localhost/doc?user=crate&TC_REUSABLE=true&TC_INITSCRIPT=init.sql";
         System.out.printf("Connecting to %s%n", connectionUrl);
 
         // Invoke `SHOW CREATE TABLE ...` query.
@@ -39,7 +39,7 @@ public class TestSqlInitialization {
      */
     @Test
     public void testTcInitArbitraryFile() throws SQLException, IOException {
-        String connectionUrl = "jdbc:tc:cratedb:5.10://localhost/doc?user=crate&TC_REUSABLE=true&TC_INITSCRIPT=file:src/test/resources/init.sql";
+        String connectionUrl = "jdbc:tc:cratedb:6.2://localhost/doc?user=crate&TC_REUSABLE=true&TC_INITSCRIPT=file:src/test/resources/init.sql";
         System.out.printf("Connecting to %s%n", connectionUrl);
 
         // Invoke `SHOW CREATE TABLE ...` query.
@@ -55,7 +55,7 @@ public class TestSqlInitialization {
      */
     @Test
     public void testTcInitFunction() throws SQLException, IOException {
-        String connectionUrl = "jdbc:tc:cratedb:5.10://localhost/doc?user=crate&TC_INITFUNCTION=io.crate.example.testing.utils.TestingHelpers::sqlInitFunction";
+        String connectionUrl = "jdbc:tc:cratedb:6.2://localhost/doc?user=crate&TC_INITFUNCTION=io.crate.example.testing.utils.TestingHelpers::sqlInitFunction";
         System.out.printf("Connecting to %s%n", connectionUrl);
 
         // Invoke `SHOW CREATE TABLE ...` query.

--- a/testing/testcontainers/java/src/test/java/io/crate/example/testing/utils/TestingHelpers.java
+++ b/testing/testcontainers/java/src/test/java/io/crate/example/testing/utils/TestingHelpers.java
@@ -15,12 +15,12 @@ public final class TestingHelpers {
     public static DockerImageName nameFromLabel(String label) {
         String fullImageName;
         if (label == null) {
-            fullImageName = "crate:latest";
+            fullImageName = "docker.io/crate:latest";
         } else {
             if (label.equals("nightly")) {
-                fullImageName = "crate/crate:nightly";
+                fullImageName = "docker.io/crate/crate:nightly";
             } else {
-                fullImageName = String.format("crate:%s", label);
+                fullImageName = String.format("docker.io/crate:%s", label);
             }
         }
         return DockerImageName.parse(fullImageName).asCompatibleSubstituteFor("crate");

--- a/testing/testcontainers/java/src/test/java/io/crate/example/testing/utils/TestingHelpers.java
+++ b/testing/testcontainers/java/src/test/java/io/crate/example/testing/utils/TestingHelpers.java
@@ -13,6 +13,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public final class TestingHelpers {
 
     public static DockerImageName nameFromLabel(String label) {
+        // The three branches correctly map to two distinct Docker Hub repos:
+        // - `docker.io/crate:<label>` resolves to the official library/crate image
+        //   for stable releases (where tags like 6.2 and latest are maintained)
+        // - `docker.io/crate/crate:nightly` targets the separate crate/crate
+        //   repository for testing and nightly builds.
         String fullImageName;
         if (label == null) {
             fullImageName = "docker.io/crate:latest";


### PR DESCRIPTION
## About

A quick sweep to bring CrateDB version references up to speed, to improve quality assurance details.

```shell
ag 'crate:' | grep -i image
```

## Details

### CrateDB nightly FTW

[QA: Use CrateDB nightly across the board](https://github.com/crate/cratedb-examples/commit/90237f654a60c6290d62dce0180a918d6a0411f0)

This repository includes a number of recipes that are used both to demonstrate functionalities around CrateDB to users, but also for _validating_ it on a nightly basis. While we used CrateDB nightly at most occasions already, there are still a few spots where we selected more stable variants of CrateDB for "tutorial"-like purposes.

However, because we can see the whole volume of integration tests regularly discovers regressions on CrateDB nightly, **let's emphasize the QA leverage over other concerns** by _really_ testing against CrateDB nightly where it does not happen yet.

The most recent observation was discovered by the integration test suite against the Fivetran SDK tester, which also uses CrateDB nightly. Without such opportunities, corresponding issues would proceed largely unnoticed and can possibly hit production releases.

- https://github.com/crate/cratedb-fivetran-destination/issues/169
- https://github.com/crate/crate/issues/19291

### Refresh pinned versions

[CrateDB: Bump to most recent GA release 6.2, or use latest](https://github.com/crate/cratedb-examples/commit/8e40a86a0e4c43098c98050b4fa952cad51d2bde)

Note: We can use `crate:6.2`, but `crate:6.3` is not available yet.

> Docker images dance in the nightly glow,
> From pinned versions five to six they flow.

### Copy editing

[OCI: Refer to fully-qualified OCI references](https://github.com/crate/cratedb-examples/commit/4b12187455f065123fd05f94c007a2171dae4a5c)

Nothing significant. Just copy editing for canonalization purposes,
to use `docker.io/crate/crate:nightly` specifiers instead of `crate/crate:nightly`.
