### PR TITLE
Upgrade Flink to 2.0.2 and Flink job JAR to 0.8

### DIFF
--- a/framework/flink/kafka-jdbcsink-java/.env
+++ b/framework/flink/kafka-jdbcsink-java/.env
@@ -1,7 +1,7 @@
 # Software component versions.
 CONFLUENT_VERSION=7.9.0
 CRATEDB_VERSION=5.10.3
-FLINK_VERSION=1.20.1
+FLINK_VERSION=2.0.2
 KCAT_VERSION=1.7.1
 
 # Flink service configuration.
@@ -31,6 +31,6 @@ CRATEDB_HTTP_URL="${CRATEDB_HTTP_SCHEME}://${CRATEDB_USERNAME}:${CRATEDB_PASSWOR
 
 # Options for acquiring the Flink job JAR file.
 # https://github.com/crate/cratedb-flink-jobs
-FLINK_JOB_JAR_VERSION=0.5
+FLINK_JOB_JAR_VERSION=0.8
 FLINK_JOB_JAR_FILE=cratedb-flink-jobs-${FLINK_JOB_JAR_VERSION}.jar
 FLINK_JOB_JAR_URL=https://github.com/crate/cratedb-flink-jobs/releases/download/${FLINK_JOB_JAR_VERSION}/${FLINK_JOB_JAR_FILE}


### PR DESCRIPTION
Updates the Kafka → Flink → CrateDB example (`framework/flink/kafka-jdbcsink-java`) to run on **Apache Flink 2.0.2** and pull the matching **cratedb-flink-jobs 0.8** job JAR. This resolves crate/cratedb-examples#833 (refresh the Flink resources after the move past 1.20.1) and brings the example onto the current Flink major.
  
Two coupled values in `.env`:

- `FLINK_VERSION`: `1.20.1` → `2.0.2` — the `flink:<version>` Docker image the rig runs.
- `FLINK_JOB_JAR_VERSION`: `0.5` → `0.8` — the released job JAR the rig fetches. 

0.6 was fubar (The JARs for 0.6 were incompatible with the example's runtime, so the pipeline could not complete end to end.), and 0.7 is the working flink1.2 tag, and 0.8 (latest) is the working flink2.0 tag

These two must move together: the 0.8 JAR is built against the Flink 2.0 connector line (`flink-connector-jdbc-*:4.0.0-2.0`, `flink-connector-kafka:4.0.1-2.0`), which only runs on a Flink 2.0 cluster. 

  ### Why 0.8 (and not 0.7)
  
  cratedb-flink-jobs cut two releases:
  - **0.7** — a conservative fix that stays on the Flink 1.20.1 line.
  - **0.8** — the migration to Flink 2.0.2 / Java 17 (split JDBC connector artifacts, Kafka 4.0.1-2.0, Sink V2 API).

  Since this example tracks the current Flink, it goes straight to 0.8.
  
  ### Verification

  Ran the rig end to end locally against the released 0.8 JAR on `flink:2.0.2`:

```bash
  bash test.sh
  → SUCCESS: Database table contains expected number of 5000 records.

  5000 NYC taxi records flow Kafka → Flink → CrateDB and land in the `taxi_rides` table, which is the example's pass condition.
```

  ### Related

  - Job source / releases: https://github.com/crate/cratedb-flink-jobs (0.8)
  - Closes crate/cratedb-examples#833
  - Closes crate/cratedb-flink-jobs#59
  - Closes crate/cratedb-examples#859