### PR TITLE
Python/SQLAlchemy: Stop testing experimental features

### DIFF
--- a/by-dataframe/pandas/requirements.txt
+++ b/by-dataframe/pandas/requirements.txt
@@ -1,6 +1,9 @@
 click<9
 colorlog<7
-crate>=2.1.2
+crate>=2.1.2,<2.2
 pandas>=2.3,<3.1
 pueblo>=0.0.18
-sqlalchemy-cratedb[all] @ git+https://github.com/crate-workbench/sqlalchemy-cratedb@amo/postgresql-async
+sqlalchemy-cratedb[all]<0.43
+
+# Needed for async support.
+# sqlalchemy-cratedb[all] @ git+https://github.com/crate-workbench/sqlalchemy-cratedb@amo/postgresql-async

--- a/by-dataframe/pandas/test_read.py
+++ b/by-dataframe/pandas/test_read.py
@@ -1,16 +1,25 @@
 import shlex
 import subprocess
 
+import pytest
+
 
 def run(command: str):
     subprocess.check_call(shlex.split(command))
 
 
+def test_read_standard():
+    cmd = "time python read_pandas.py --dburi=crate://crate@localhost:4200"
+    run(cmd)
+
+
+@pytest.mark.skip("Needs https://github.com/crate/sqlalchemy-cratedb/pull/11")
 def test_read_urllib3():
     cmd = "time python read_pandas.py --dburi=crate+urllib3://crate@localhost:4200"
     run(cmd)
 
 
+@pytest.mark.skip("Needs https://github.com/crate/sqlalchemy-cratedb/pull/11")
 def test_read_psycopg3():
     cmd = "time python read_pandas.py --dburi=crate+psycopg://crate@localhost:5432"
     run(cmd)

--- a/by-language/python-sqlalchemy/requirements.txt
+++ b/by-language/python-sqlalchemy/requirements.txt
@@ -1,6 +1,10 @@
 click<9
 colorlog<7
-crate>=2.1.2
+crate>=2.1.2,<2.2
 pueblo>=0.0.18
-sqlalchemy>=2.0.49,<2.1
-sqlalchemy-cratedb[all] @ git+https://github.com/crate-workbench/sqlalchemy-cratedb@amo/postgresql-async
+sqlalchemy>=2.0.49
+sqlalchemy-cratedb[all]<0.43
+
+# Needed for async support.
+# sqlalchemy-cratedb[all] @ git+https://github.com/crate-workbench/sqlalchemy-cratedb@amo/postgresql-async
+greenlet

--- a/by-language/python-sqlalchemy/sync_table.py
+++ b/by-language/python-sqlalchemy/sync_table.py
@@ -52,7 +52,8 @@ class SynchronousTableExample:
         """
         Provide an SQLAlchemy engine object.
         """
-        return sa.create_engine(self.dsn, isolation_level="AUTOCOMMIT", echo=True)
+        # TODO: Add `isolation_level="AUTOCOMMIT"` with sqlalchemy-cratedb >= 0.43
+        return sa.create_engine(self.dsn, echo=True)
 
     @property
     @lru_cache
@@ -149,7 +150,9 @@ def run_example(dsn: str):
 
 def run_drivers(drivers: t.List[str]):
     for driver in drivers:
-        if driver == "urllib3":
+        if driver == "cratedb":
+            dsn = "crate://localhost:4200/"
+        elif driver == "urllib3":
             dsn = "crate+urllib3://localhost:4200/doc"
         elif driver == "psycopg":
             dsn = "crate+psycopg://crate@localhost:5432/doc"

--- a/by-language/python-sqlalchemy/test.py
+++ b/by-language/python-sqlalchemy/test.py
@@ -27,16 +27,24 @@ def test_insert_efficient_unknown(capfd):
     assert "ValueError: Unknown variant: unknown" in err
 
 
-def test_sync_table():
+def test_sync_table_standard():
+    cmd = "time python sync_table.py cratedb"
+    run(cmd)
+
+
+@pytest.mark.skip("PostgreSQL support is experimental")
+def test_sync_table_advanced():
     cmd = "time python sync_table.py urllib3 psycopg"
     run(cmd)
 
 
+@pytest.mark.skip("Async support is experimental")
 def test_async_table():
     cmd = "time python async_table.py psycopg asyncpg"
     run(cmd)
 
 
+@pytest.mark.skip("Async support is experimental")
 def test_async_streaming():
     cmd = "time python async_streaming.py psycopg asyncpg"
     run(cmd)


### PR DESCRIPTION
## About
To increase the stability of integration tests touched hereby, leave testing against the stale [`amo/postgresql-async`](https://github.com/crate/sqlalchemy-cratedb/pull/11) development branch behind.

## Details
`amo/postgresql-async` is a development branch, and it can no longer easily be refreshed. It is better to demonstrate only GA features anyway, and flag the experimental ones appropriately.

## Reason

All those CI jobs are failing otherwise.

- crate/cratedb-examples#1799
- crate/cratedb-examples#1808
- crate/cratedb-examples#1816