### PR TITLE
Time series analysis: Update to PyCaret 3.5

### DIFF
--- a/topic/machine-learning/pycaret/requirements.txt
+++ b/topic/machine-learning/pycaret/requirements.txt
@@ -2,7 +2,7 @@
 dask==2024.12.1
 mlflow-cratedb==3.12.0
 plotly<6.8
-pycaret[models,parallel,test]==3.3.2
+pycaret-core[models,parallel,test]<3.6
 pydantic<3
 python-dotenv<2
 sqlalchemy==2.*

--- a/topic/timeseries/requirements.txt
+++ b/topic/timeseries/requirements.txt
@@ -1,7 +1,7 @@
 cratedb-toolkit[datasets]>=0.0.49
 refinitiv-data<1.7
 pandas==2.0.*
-pycaret==3.3.2
+pycaret-core<3.6
 pydantic<3
 sqlalchemy==2.0.*
 sqlalchemy-cratedb>=0.43.1


### PR DESCRIPTION
Hi there. [pycaret-core](https://pypi.org/project/pycaret-core/) 3.5.0, the new community-maintained and permissive-licensed version of PyCaret, has been released recently. The most recent version of the original [pycaret](https://pypi.org/project/pycaret/) package was released on Apr 28, 2024, quite a while ago, and the original [pycaret/pycaret](https://github.com/pycaret/pycaret) project changed its license to FSL-1.1-MIT the other day.

/cc @bgunebakan, @florinutz, @fkiraly, @WilliamJudge94, @siddharth7113