### PR TITLE
Superset: Pin flask-caching<2.5 to unbreak the nightly pipeline

### DIFF
--- a/application/apache-superset/requirements.txt
+++ b/application/apache-superset/requirements.txt
@@ -1,4 +1,12 @@
 apache-superset
+# Apache Superset <=6.1.0 is incompatible with flask-caching 2.5.0.
+# flask-caching 2.5.0 injects an `ignore_delete_many_errors` option into the
+# cache backend kwargs, which `SupersetMetastoreCache` does not accept, so
+# app creation fails. Superset's own lockfile pins 2.4.1, but the sdist/wheel
+# dependency is the loose `flask-caching<3,>=2.1.0`, so plain pip installs
+# resolve to 2.5.0 and break.
+# https://github.com/apache/superset/issues/TBD
+flask-caching<2.5
 flask-jwt-extended>=4.7.4
 sqlalchemy-cratedb>=0.43.1
 rich


### PR DESCRIPTION
flask-caching 2.5.0 (released 2026-08-24) unconditionally injects an `ignore_delete_many_errors` entry into the cache backend options in `_set_cache()`. Superset's `SupersetMetastoreCache.factory()` splats those options into `__init__`, which only accepts `namespace`, `codec` and `default_timeout`, so app creation fails:

    TypeError: SupersetMetastoreCache.__init__() got an unexpected keyword
               argument 'ignore_delete_many_errors'

`SupersetMetastoreCache` is Superset's default backend for FILTER_STATE_CACHE_CONFIG and EXPLORE_FORM_DATA_CACHE_CONFIG, so `superset db upgrade` aborts during test setup and the whole matrix leg fails.

Only the 6.1.0 x py3.11 and 6.1.0 x py3.12 legs were affected, because flask-caching 2.5.0 requires `flask>=3.0` and `python>=3.11`:

    | matrix leg              | flask | flask-caching |        |
    |-------------------------|-------|---------------|--------|
    | 4.* / 6.0.0 (all py)    | 2.3.3 | 2.4.1         | pass   |
    | 6.1.0 / py3.10          | 3.1.3 | 2.4.1         | pass   |
    | 6.1.0 / py3.11, py3.12  | 3.1.3 | 2.5.0         | fail   |

Superset pins flask-caching==2.4.1 in its own requirements/base.txt, so upstream CI does not see this; the published distribution only carries the loose `flask-caching<3,>=2.1.0`, which is what lets 2.5.0 in here.

The nightly workflow has failed on every run since 2026-08-25, the day after flask-caching 2.5.0 was published. Last green run was 2026-08-24.

## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
